### PR TITLE
Comment out line 105: [self styleLightContent:nil]; // match default bac...

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -102,7 +102,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     
     [self initializeStatusBarBackgroundView];
 
-    [self styleLightContent:nil]; // match default backgroundColor of #000000
+    // [self styleLightContent:nil]; // match default backgroundColor of #000000
     self.viewController.view.autoresizesSubviews = YES;
     
     NSString* setting;


### PR DESCRIPTION
...kgroundColor of #000000

Don't need it, just leave it as is. If we select Default in Xcode project settings then status bar text is black during app starting then changed to white because this line. Comment out this line will leave status bar text always black (as default).

[self styleLightContent:nil]; // match default backgroundColor of #000000
