### PR TITLE
Update backgroundColorByHexString function

### DIFF
--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -71,7 +71,7 @@ var StatusBar = {
     },
 
     backgroundColorByHexString: function (hexString) {
-        if (hexString.charAt(0) === "#") {
+        if (hexString.charAt(0) !== "#") {
             hexString = "#" + hexString;
         }
 


### PR DESCRIPTION
The implementation when `hexString.length == 4` was a bit off. The current version either doesn't actually use the `split` variable, so that variable could be removed, or used in place accessing the string characters as they are now. Opted for the former in this case, though it doesn't really matter.

Since the length is always going to be a number, also changed to `===` instead, as well as updated the check for `#` at the beginning of the string. Since it's always looking for the `#` tat the beginning `charAt(0)` seems to be a better fit.
