### PR TITLE
CB-7486: Remove StatusBarBackgroundColor

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -54,7 +54,6 @@
                 <param name="ios-package" value="CDVStatusBar" onload="true" />
             </feature>
             <preference name="StatusBarOverlaysWebView" value="true" />
-            <preference name="StatusBarBackgroundColor" value="#000000" />
             <preference name="StatusBarStyle" value="lightcontent" />
         </config-file>
 


### PR DESCRIPTION
This should probably not be a default ios setting:

```
<preference name="StatusBarBackgroundColor" value="#000000" />
```

It makes it impossible to unset the initial background color (for transparent backgrounds).  Instead just have the default as no background color (which will effectively be transparent), and then allow users to override that with a desired color.
