### PR TITLE
ios 8 landscape issue

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -168,7 +168,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 - (void) initializeStatusBarBackgroundView
 {
     CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-    if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+    if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation) && !IsAtLeastiOSVersion(@"8.0")) {
         // swap width and height. set origin to zero
         statusBarFrame = CGRectMake(0, 0, statusBarFrame.size.height, statusBarFrame.size.width);
     }
@@ -205,7 +205,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
         CGRect frame = self.webView.frame;
 
-        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation) && !IsAtLeastiOSVersion(@"8.0")) {
             frame.origin.y = statusBarFrame.size.width;
             frame.size.height -= statusBarFrame.size.width;
         } else {


### PR DESCRIPTION
When starting an app in landscape mode in ios 8 and then calling StatusBar.overlaysWebView(false), the screen would be pushed down all the way.  Changing the orientation did not fix the issue, leaving the page pushed down the width of the device.

We found that excluding the changes above in ios 8 fixed the issue, although it's possible that this is hiding a landscape orientation bug in ios 8 that may get fixed later.
