### PR TITLE
CB-8001

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -161,7 +161,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
 - (void) _ready:(CDVInvokedUrlCommand*)command
 {
-    _eventsCallbackId = command.callbackId;
+    _eventsCallbackId = [command.callbackId retain];
     [self updateIsVisible:![UIApplication sharedApplication].statusBarHidden];
 }
 


### PR DESCRIPTION
StatusBar Plugin 0.1.8 crashes application on tap
Reproduced only in projects without ARC
Now retaining callbackId, without a retain there it gets dealloced and crashes the app when fireTappedEvent is triggered