### PR TITLE
update docs for StatusBarBackgroundColor

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -37,7 +37,7 @@ Preferences
 
         <preference name="StatusBarOverlaysWebView" value="true" />
 
-- __StatusBarBackgroundColor__ (color hex string, defaults to #000000). On iOS 7, set the background color of the statusbar by a hex string (#RRGGBB) at startup.
+- __StatusBarBackgroundColor__ (color hex string, no default value). On iOS 7, set the background color of the statusbar by a hex string (#RRGGBB) at startup. If this value is not set, the background color will be transparent.
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 


### PR DESCRIPTION
The default value is no longer black. (CB-7486)