### PR TITLE
Allow setting the statusbar backgroundcolor on Android

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -203,6 +203,7 @@ Supported Platforms
 -------------------
 
 - iOS
+- Android 5+
 - Windows Phone 7
 - Windows Phone 8
 - Windows Phone 8.1
@@ -227,6 +228,7 @@ Supported Platforms
 -------------------
 
 - iOS
+- Android 5+
 - Windows Phone 7
 - Windows Phone 8
 - Windows Phone 8.1

--- a/doc/index.md
+++ b/doc/index.md
@@ -37,17 +37,21 @@ Preferences
 
         <preference name="StatusBarOverlaysWebView" value="true" />
 
-- __StatusBarBackgroundColor__ (color hex string, defaults to #000000). On iOS 7, set the background color of the statusbar by a hex string (#RRGGBB) at startup.
+- __StatusBarBackgroundColor__ (color hex string, defaults to #000000). On iOS 7 and Android 5, set the background color of the statusbar by a hex string (#RRGGBB) at startup.
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
-
-- __AndroidStatusBarBackgroundColor__ (color hex string, defaults to the Android theme default). On Android 5 and up, the background color can be set by a hex string (#RRGGBB) at startup. We don't use the same property as for iOS because on iOS you typically want the statusbar to have the same color as the app background, but the Android 5+ guidelines specify using a different color than you apps main color, so the value of this property is typically different than the one specified by StatusBarBackgroundColor.
-
-        <preference name="AndroidStatusBarBackgroundColor" value="#000000" />
 
 - __StatusBarStyle__ (status bar style, defaults to lightcontent). On iOS 7, set the status bar style. Available options default, lightcontent, blacktranslucent, blackopaque.
 
         <preference name="StatusBarStyle" value="lightcontent" />
+
+### Android Quirks
+The Android 5+ guidelines specify using a different color for the statusbar than your main app color (unlike the uniform statusbar color of many iOS 7+ apps), so you may want to set the statusbar color at runtime instead via `StatusBar.backgroundColorByHexString` or `StatusBar.backgroundColorByName`. One way to do that would be:
+```js
+if (cordova.platformId == 'android') {
+    StatusBar.backgroundColorByHexString("#333");
+}
+```
 
 Hiding at startup
 -----------

--- a/doc/index.md
+++ b/doc/index.md
@@ -41,6 +41,10 @@ Preferences
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 
+- __AndroidStatusBarBackgroundColor__ (color hex string, defaults to the Android theme default). On Android 5 and up, the background color can be set by a hex string (#RRGGBB) at startup. We don't use the same property as for iOS because on iOS you typically want the statusbar to have the same color as the app background, but the Android 5+ guidelines specify using a different color than you apps main color, so the value of this property is typically different than the one specified by StatusBarBackgroundColor.
+
+        <preference name="AndroidStatusBarBackgroundColor" value="#000000" />
+
 - __StatusBarStyle__ (status bar style, defaults to lightcontent). On iOS 7, set the status bar style. Available options default, lightcontent, blacktranslucent, blackopaque.
 
         <preference name="StatusBarStyle" value="lightcontent" />

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -57,8 +57,8 @@ public class StatusBar extends CordovaPlugin {
                 Window window = cordova.getActivity().getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 
-                // Read 'AndroidStatusBarBackgroundColor' from config.xml. We expect a hex string like #999999.
-                setStatusBarBackgroundColor(preferences.getString("AndroidStatusBarBackgroundColor", null));
+                // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
+                setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
             }
         });
     }
@@ -108,7 +108,7 @@ public class StatusBar extends CordovaPlugin {
                     try {
                         setStatusBarBackgroundColor(args.getString(0));
                     } catch (JSONException ignore) {
-                        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, "Invalid hexString argument, use '#RRGGBB'"));
+                        Log.e(TAG, "Invalid hexString argument, use f.i. '#777777'");
                     }
                 }
             });
@@ -119,8 +119,8 @@ public class StatusBar extends CordovaPlugin {
     }
 
     private void setStatusBarBackgroundColor(final String colorPref) {
-        if (colorPref != null && !colorPref.isEmpty()) {
-            if (Build.VERSION.SDK_INT >= 21) {
+        if (Build.VERSION.SDK_INT >= 21) {
+            if (colorPref != null && !colorPref.isEmpty()) {
                 final Window window = cordova.getActivity().getWindow();
                 // Method and constants not available on all SDKs but we want to be able to compile this code with any SDK
                 window.clearFlags(0x04000000); // SDK 19: WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
@@ -128,6 +128,8 @@ public class StatusBar extends CordovaPlugin {
                 try {
                     // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21
                     window.getClass().getDeclaredMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
+                } catch (IllegalArgumentException ignore) {
+                    Log.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
                 } catch (Exception ignore) {
                     // this should not happen, only in case Android removes this method in a version > 21
                     Log.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);


### PR DESCRIPTION
Since Android Lollipop the statusbar of your app is no longer black. On a Samsung Galaxy S5 my mostly white app now has a blue statusbar. This change gives control back to your app.