### PR TITLE
fix warning message

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -79,6 +79,7 @@ public class StatusBar extends CordovaPlugin {
         if ("_ready".equals(action)) {
             boolean statusBarVisible = (window.getAttributes().flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) == 0;
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, statusBarVisible));
+            return true;
         }
 
         if ("show".equals(action)) {


### PR DESCRIPTION
This change is fix for the following warning message at startup:

W/CordovaPlugin( 6470): Attempted to send a second callback for ID:
StatusBar1091036409
W/CordovaPlugin( 6470): Result was: "Invalid action"