### PR TITLE
CB-9214 - [iOS] Landscape webview height is calculated wrong

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -370,11 +370,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
             CGRect frame = self.webView.frame;
             frame.origin.y = 0;
             if (!self.statusBarOverlaysWebView) {
-                if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation) && !IsAtLeastiOSVersion(@"8.0")) {
-                    frame.size.height += statusBarFrame.size.width;
-                } else {
-                    frame.size.height += statusBarFrame.size.height;
-                }
+                frame.size.height += MIN(statusBarFrame.size.height, statusBarFrame.size.width);
             }
 
             self.webView.frame = frame;

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -370,7 +370,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
             CGRect frame = self.webView.frame;
             frame.origin.y = 0;
             if (!self.statusBarOverlaysWebView) {
-                if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+                if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation) && !IsAtLeastiOSVersion(@"8.0")) {
                     frame.size.height += statusBarFrame.size.width;
                 } else {
                     frame.size.height += statusBarFrame.size.height;


### PR DESCRIPTION
Fix for the incorrectly calculated statusbar height, when hiding the statusbar in landscape orientation in iOS 8.

At first I thought I use the IsAtLeastiOSVersion macro, but then I noticed it had already been tested in https://issues.apache.org/jira/browse/CB-7549, so I replaced it with a more fool proof solution..