### PR TITLE
CB-9076 Fixed StatusBarOverlaysWebView

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,7 +55,6 @@
                 <param name="ios-package" value="CDVStatusBar" />
                 <param name="onload" value="true" />
             </feature>
-            <preference name="StatusBarOverlaysWebView" value="true" />
             <preference name="StatusBarStyle" value="lightcontent" />
         </config-file>
 


### PR DESCRIPTION
Related issue: https://issues.apache.org/jira/browse/CB-9076

The default value can be removed since it is set in the code:
```objectivec
// src/ios/CDVStatusBar.m, line 104
_statusBarOverlaysWebView = YES; // default
```