### PR TITLE
 CB-10047 fix iOS 8 deprecated warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-statusbar",
-  "version": "2.0.1-dev",
+  "version": "2.0.0",
   "description": "Cordova StatusBar Plugin",
   "cordova": {
     "id": "cordova-plugin-statusbar",

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-statusbar"
-    version="2.0.1-dev">
+    version="2.0.0">
     <name>StatusBar</name>
     <description>Cordova StatusBar Plugin</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -180,7 +180,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 - (void) initializeStatusBarBackgroundView
 {
     CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-    statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
+    statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
 
     _statusBarBackgroundView = [[UIView alloc] initWithFrame:statusBarFrame];
     _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
@@ -188,7 +188,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     _statusBarBackgroundView.autoresizesSubviews = YES;
 }
 
-- (CGRect) invertFrameIfNeeded:(CGRect)rect {
+- (CGRect) invertFrameIfNeeded:(CGRect)rect orientation:(UIInterfaceOrientation)orientation {
     // landscape is where (width > height). On iOS < 8, we need to invert since frames are
     // always in Portrait context
     if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) && (rect.size.width < rect.size.height)) {
@@ -412,7 +412,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
                 // from the current one. Therefore we need to expand the statusBarBackgroundView as well to the
                 // statusBar's current size
                 CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-                statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
+                statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
                 CGRect sbBgFrame = _statusBarBackgroundView.frame;
                 sbBgFrame.size = statusBarFrame.size;
                 _statusBarBackgroundView.frame = sbBgFrame;
@@ -434,7 +434,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     
     CGRect bounds = [[UIScreen mainScreen] bounds];
     
-    bounds = [self invertFrameIfNeeded:bounds];
+    bounds = [self invertFrameIfNeeded:bounds orientation:self.viewController.interfaceOrientation];
     
     if (UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation])) {
         self.viewController.view.frame = bounds;
@@ -445,7 +445,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     if (!self.statusBarOverlaysWebView) {
         
         CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-        statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
+        statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
         
         CGRect frame = self.webView.frame;
         frame.origin.y = statusBarFrame.size.height;

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -180,7 +180,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 - (void) initializeStatusBarBackgroundView
 {
     CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-    statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+    statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
 
     _statusBarBackgroundView = [[UIView alloc] initWithFrame:statusBarFrame];
     _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
@@ -188,7 +188,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     _statusBarBackgroundView.autoresizesSubviews = YES;
 }
 
-- (CGRect) invertFrameIfNeeded:(CGRect)rect orientation:(UIInterfaceOrientation)orientation {
+- (CGRect) invertFrameIfNeeded:(CGRect)rect {
     // landscape is where (width > height). On iOS < 8, we need to invert since frames are
     // always in Portrait context
     if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) && (rect.size.width < rect.size.height)) {
@@ -412,7 +412,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
                 // from the current one. Therefore we need to expand the statusBarBackgroundView as well to the
                 // statusBar's current size
                 CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-                statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+                statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
                 CGRect sbBgFrame = _statusBarBackgroundView.frame;
                 sbBgFrame.size = statusBarFrame.size;
                 _statusBarBackgroundView.frame = sbBgFrame;
@@ -434,7 +434,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     
     CGRect bounds = [[UIScreen mainScreen] bounds];
     
-    bounds = [self invertFrameIfNeeded:bounds orientation:self.viewController.interfaceOrientation];
+    bounds = [self invertFrameIfNeeded:bounds];
     
     if (UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation])) {
         self.viewController.view.frame = bounds;
@@ -445,7 +445,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     if (!self.statusBarOverlaysWebView) {
         
         CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-        statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+        statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
         
         CGRect frame = self.webView.frame;
         frame.origin.y = statusBarFrame.size.height;

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-statusbar-tests"
-    version="2.0.1-dev">
+    version="2.0.0">
     <name>Cordova StatusBar Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
Removed all references to self.viewController.interfaceOrientation,
they weren’t really used on invertFrameIfNeeded and are deprecated on
iOS 8
Removed orientation param on invertFrameIfNeeded as it wasn’t being
used.