### PR TITLE
CB-10047 fix iOS 8 deprecated warnings

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -190,7 +190,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         statusBarFrame.origin.y = 0;
     }
 
-    statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+    statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
 
     _statusBarBackgroundView = [[UIView alloc] initWithFrame:statusBarFrame];
     _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
@@ -198,7 +198,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     _statusBarBackgroundView.autoresizesSubviews = YES;
 }
 
-- (CGRect) invertFrameIfNeeded:(CGRect)rect orientation:(UIInterfaceOrientation)orientation {
+- (CGRect) invertFrameIfNeeded:(CGRect)rect {
     // landscape is where (width > height). On iOS < 8, we need to invert since frames are
     // always in Portrait context
     if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) && (rect.size.width < rect.size.height)) {
@@ -422,7 +422,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
                 // from the current one. Therefore we need to expand the statusBarBackgroundView as well to the
                 // statusBar's current size
                 CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-                statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+                statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
                 CGRect sbBgFrame = _statusBarBackgroundView.frame;
                 sbBgFrame.size = statusBarFrame.size;
                 _statusBarBackgroundView.frame = sbBgFrame;
@@ -444,7 +444,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     
     CGRect bounds = [[UIScreen mainScreen] bounds];
     
-    bounds = [self invertFrameIfNeeded:bounds orientation:self.viewController.interfaceOrientation];
+    bounds = [self invertFrameIfNeeded:bounds];
     
     if (UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation])) {
         self.viewController.view.frame = bounds;
@@ -455,7 +455,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     if (!self.statusBarOverlaysWebView) {
         
         CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-        statusBarFrame = [self invertFrameIfNeeded:statusBarFrame orientation:self.viewController.interfaceOrientation];
+        statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
         
         CGRect frame = self.webView.frame;
         frame.origin.y = statusBarFrame.size.height;


### PR DESCRIPTION
Removed all references to self.viewController.interfaceOrientation,
they weren’t really used on invertFrameIfNeeded and are deprecated on
iOS 8
Removed orientation param on invertFrameIfNeeded as it wasn’t being
used.