### PR TITLE
CB-10866: Adding engine info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
     "test": "npm run jshint",
     "jshint": "node node_modules/jshint/bin/jshint www && node node_modules/jshint/bin/jshint src && node node_modules/jshint/bin/jshint tests"
   },
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
+  "engines": {
+    "cordovaDependencies": {
+      "0.1.0": {
+        "cordova": ">=3.0.0"
+      }
     }
-  ],
+  },
   "author": "Apache Software Foundation",
   "license": "Apache 2.0",
   "devDependencies": {


### PR DESCRIPTION
Checked Github to see when the constraint was added (earliest was 0.1.0 512a1388c65fc099b56c0a40e6c63458b2d029eb)