### PR TITLE
CB-11197 Keep status bar hidden when keyboard pops up

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -96,9 +96,10 @@ public class StatusBar extends CordovaPlugin {
                         uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
 
                         window.getDecorView().setSystemUiVisibility(uiOptions);
-                        return;
                     }
 
+                    // CB-11197 We still need to update LayoutParams to force status bar
+                    // to be hidden when entering e.g. text fields
                     window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
             });
@@ -117,9 +118,10 @@ public class StatusBar extends CordovaPlugin {
                                 | View.SYSTEM_UI_FLAG_FULLSCREEN;
 
                         window.getDecorView().setSystemUiVisibility(uiOptions);
-                        return;
                     }
 
+                    // CB-11197 We still need to update LayoutParams to force status bar
+                    // to be hidden when entering e.g. text fields
                     window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                 }
             });


### PR DESCRIPTION
This PR fixes incorrect behavior of status bar when it shows up when keyboard pops up even if it was hidden previously

See [CB-11197](https://issues.apache.org/jira/browse/CB-11197) for details