### PR TITLE
CB-11485: (ios) fix resize on rotation with popover

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -454,7 +454,11 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
                 bounds = CGRectMake(0, 0, bounds.size.width, bounds.size.height);
             } else {
                 // iOS7, iOS9+
-                bounds = CGRectMake(0, 0, bounds.size.height, bounds.size.width);
+                if ([self.viewController.presentedViewController.presentationController isKindOfClass:[UIPopoverPresentationController class]]) {
+                    bounds = CGRectMake(0, 0, bounds.size.width, bounds.size.height);
+                } else {
+                    bounds = CGRectMake(0, 0, bounds.size.height, bounds.size.width);
+                }
             }
         }
         self.webView.frame = bounds;


### PR DESCRIPTION
This PR fix the webview resize problem when a popover is present

### Platforms affected
iOS

### What does this PR do?
Fixes CB-11485 

### What testing has been done on this change?
Tested on iOS 7, 8 and 9 iPads when a popover is present

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [] Added automated test coverage as appropriate for this change.

