### PR TITLE
CB-11287: (ios) - fix webview resize after modal on iPhones

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -454,7 +454,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
                 bounds = CGRectMake(0, 0, bounds.size.width, bounds.size.height);
             } else {
                 // iOS7, iOS9+
-                if ([self.viewController.presentedViewController.presentationController isKindOfClass:[UIPopoverPresentationController class]]) {
+                if ([self.viewController.presentedViewController.presentationController isKindOfClass:[UIPopoverPresentationController class]] || UI_USER_INTERFACE_IDIOM() != UIUserInterfaceIdiomPad) {
                     bounds = CGRectMake(0, 0, bounds.size.width, bounds.size.height);
                 } else {
                     bounds = CGRectMake(0, 0, bounds.size.height, bounds.size.width);


### PR DESCRIPTION

### Platforms affected
iOS

### What does this PR do?
Fixes CB-11287

### What testing has been done on this change?
Tested on iPhones, presenting a modal (camera picker) on landscape mode and dismissing it.

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.