### PR TITLE
CB-11858: Add possibility to utilize Android M feature "LightStatusBar"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Preferences
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 
-- __StatusBarStyle__ (status bar style, defaults to lightcontent). On iOS 7, set the status bar style. Available options default, lightcontent, blacktranslucent, blackopaque.
+- __StatusBarStyle__ (status bar style, defaults to black foreground). On iOS 7, set the status bar style. Available options default, lightcontent, blacktranslucent ([deprecated](https://developer.apple.com/reference/uikit/uistatusbarstyle)), blackopaque ([deprecated](https://developer.apple.com/reference/uikit/uistatusbarstyle)).
 
         <preference name="StatusBarStyle" value="lightcontent" />
 
@@ -101,8 +101,8 @@ Although in the global scope, it is not available until after the `deviceready` 
 - StatusBar.overlaysWebView
 - StatusBar.styleDefault
 - StatusBar.styleLightContent
-- StatusBar.styleBlackTranslucent
-- StatusBar.styleBlackOpaque
+- StatusBar.styleBlackTranslucent (deprecated, use styleDefault)
+- StatusBar.styleBlackOpaque (deprecated, use styleLightContent)
 - StatusBar.backgroundColorByName
 - StatusBar.backgroundColorByHexString
 - StatusBar.hide

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -60,6 +60,22 @@ public class StatusBar extends CordovaPlugin {
 
                 // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
                 setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
+                
+                //Since Android M, it's possible to enable LightStatusBar (white)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    int newUiVisibility = window.getDecorView().getSystemUiVisibility();
+                    String option = preferences.getString("StatusBarStyle", "lightcontent");
+
+                    if (option.equals("blackopaque")) {
+                        //Dark Text to show up on your light status bar
+                        newUiVisibility |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+                    } else {
+                        //Light Text to show up on your dark status bar
+                        newUiVisibility &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+                    }
+
+                    window.getDecorView().setSystemUiVisibility(newUiVisibility);
+                }
             }
         });
     }

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -62,20 +62,7 @@ public class StatusBar extends CordovaPlugin {
                 setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
                 
                 //Since Android M, it's possible to enable LightStatusBar (white)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    int newUiVisibility = window.getDecorView().getSystemUiVisibility();
-                    String option = preferences.getString("StatusBarStyle", "lightcontent");
-
-                    if (option.equals("blackopaque")) {
-                        //Dark Text to show up on your light status bar
-                        newUiVisibility |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-                    } else {
-                        //Light Text to show up on your dark status bar
-                        newUiVisibility &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-                    }
-
-                    window.getDecorView().setSystemUiVisibility(newUiVisibility);
-                }
+                setStatusBarStyle(preferences.getString("StatusBarStyle", "default"));
             }
         });
     }
@@ -158,6 +145,26 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
+        if ("styleDefault".equals(action) || "styleBlackTranslucent".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    setStatusBarStyle("default");
+                }
+            });
+            return true;
+        }
+
+        if ("styleLightContent".equals(action) || "styleBlackOpaque".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    setStatusBarStyle("lightcontent");
+                }
+            });
+            return true;
+        }
+
         return false;
     }
 
@@ -178,6 +185,23 @@ public class StatusBar extends CordovaPlugin {
                     LOG.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);
                 }
             }
+        }
+    }
+
+    private void setStatusBarStyle(final String style) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Window window = cordova.getActivity().getWindow();
+            int newUiVisibility = window.getDecorView().getSystemUiVisibility();
+
+            if (style.equals("default") || style.equals("blacktranslucent")) {
+                //Dark Text to show up on a light status bar
+                newUiVisibility |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            } else if (style.equals("lightcontent") || style.equals("blackopaque")) {
+                //Light Text to show up on a dark status bar
+                newUiVisibility &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            }
+
+            window.getDecorView().setSystemUiVisibility(newUiVisibility);
         }
     }
 }


### PR DESCRIPTION
### Platforms affected

Android 6.0+
### What does this PR do?

This PR adds support for the LightStatusBar style in Android. I re-used the already existing config "StatusBarStyle" for this, as it has a similar effect on iOS (changing the foreground color of the status bar to black instead of white).

Something I'd like to discuss is, if "lightcontent" is the correct default value. The documentation says it is, but I don't think it actually is on iOS, is it? I think the iOS default is actually blackopaque?

Let me know what you think :)
### What testing has been done on this change?

Tested in emulator & on Samsung Galaxy S7.
### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
