### PR TITLE
CB-11191: Statusbar plugin causing issues with webview size

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -90,6 +90,11 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     }
 }
 
+-(void)cordovaViewWillAppear:(NSNotification*)notification
+{
+    [self resizeWebView];
+}
+
 -(void)statusBarDidChangeFrame:(NSNotification*)notification
 {
     //add a small delay for iOS 7 ( 0.1 seconds )
@@ -111,6 +116,8 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     [[UIApplication sharedApplication] addObserver:self forKeyPath:@"statusBarHidden" options:NSKeyValueObservingOptionNew context:NULL];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(statusBarDidChangeFrame:) name: UIApplicationDidChangeStatusBarFrameNotification object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(cordovaViewWillAppear:) name: @"CDVViewWillAppearNotification" object:nil];
 
     _statusBarOverlaysWebView = YES; // default
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Resizes the webview on CDVViewWillAppearNotification notification
This fixes resize problems when the webview is hidden by a modal

### What testing has been done on this change?


### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

