### PR TITLE
CB-10158: (ios) StatusBar issue when recovering from fullscreen video playback in landscape mode 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,6 @@ Thanks!
 
 
 ### Checklist
-- [ ] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
 - [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
 - [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
 - [ ] Added automated test coverage as appropriate for this change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-statusbar",
-  "version": "2.2.0",
+  "version": "2.2.1-dev",
   "description": "Cordova StatusBar Plugin",
   "cordova": {
     "id": "cordova-plugin-statusbar",

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-statusbar"
-    version="2.2.0">
+    version="2.2.1-dev">
     <name>StatusBar</name>
     <description>Cordova StatusBar Plugin</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -214,7 +214,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 - (void) setStatusBarOverlaysWebView:(BOOL)statusBarOverlaysWebView
 {
     // we only care about the latest iOS version or a change in setting
-    if (!IsAtLeastiOSVersion(@"7.0") || statusBarOverlaysWebView == _statusBarOverlaysWebView) {
+    if (!IsAtLeastiOSVersion(@"7.0")) {
         return;
     }
     

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-statusbar-tests"
-    version="2.2.0">
+    version="2.2.1-dev">
     <name>Cordova StatusBar Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
CB-10158: (ios) StatusBar issue when recovering from fullscreen video playback in landscape mode 
following the comment of  user 165573 in https://issues.apache.org/jira/browse/CB-10158
After trying several hacks (like hiding then showing, ...) I ended up changing the content of "setStatusBarOverlaysWebView" to avoid checking if we're setting a new value, and whenever I go back to my app after viewing a video, I call "StatusBar.overlaysWebView(false);".
