### PR TITLE
CB-10158 (ios) fix StatusBar issue when recovering from fullscreen video

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -473,16 +473,16 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
         statusBarFrame = [self invertFrameIfNeeded:statusBarFrame];
         CGRect frame = self.webView.frame;
+        CGFloat height = statusBarFrame.size.height;
 
         if (!self.statusBarOverlaysWebView) {
-            frame.origin.y = statusBarFrame.size.height;
-            frame.size.height -= statusBarFrame.size.height;
+            // CB-10158 If a full screen video is playing the status bar height will be 0, set it to 20
+            frame.origin.y = height > 0 ? height: 20;
         } else {
-            // even if overlay is used, we want to handle in-call/recording/hotspot larger status bar
-            CGFloat height = statusBarFrame.size.height;
+            // Even if overlay is used, we want to handle in-call/recording/hotspot larger status bar
             frame.origin.y = height >= 20 ? height - 20 : 0;
-            frame.size.height -= frame.origin.y;
         }
+        frame.size.height -= frame.origin.y;
         self.webView.frame = frame;
     } else {
         CGRect bounds = [[UIScreen mainScreen] applicationFrame];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
After playing a full screen video StatusBarOverlaysWebView=false wasn't respected because the height of the statusbar was 0 (the video removes it), this PR fix the problem

### What testing has been done on this change?
testing on iOS 10 device and simulator

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

