### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -61,8 +61,6 @@
                 <param name="ios-package" value="CDVStatusBar" />
                 <param name="onload" value="true" />
             </feature>
-            <preference name="StatusBarOverlaysWebView" value="true" />
-            <preference name="StatusBarStyle" value="lightcontent" />
         </config-file>
 
         <header-file src="src/ios/CDVStatusBar.h" />


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### IOS


### Removes prefrences that shoudl be controlled by the developer from the control of the plugin


### My app needs to not overlay the status bar and has a different style status bar .  I was unable to change them without creating a hook to remove these values.  once removed my status bar color changed and my app did overlay the status bar

These Values should be set in the config.xml by the app developer as needed for the app not set by the plugin.xml.  what happens is that if i want a different color or i want it to not overlay the web view I can't do it as the parser uses the last entry and overrides what needs to be there