### PR TITLE
CB-12188 Status Bar is not changing in some specific android phone (Red MI 3s Prime)

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -154,7 +154,7 @@ public class StatusBar extends CordovaPlugin {
                 window.addFlags(0x80000000); // SDK 21: WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
                 try {
                     // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21
-                    window.getClass().getDeclaredMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
+                    window.getClass().getMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
                 } catch (IllegalArgumentException ignore) {
                     LOG.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
                 } catch (Exception ignore) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Allow some 3rd party Android OS like MUI  to change status bar color. In such OS, the Window class is inherited. So window.getClass().getDeclaredMethod("setStatusBarColor", int.class) will return null, because "setStatusBarColor" is declared in parent class. 
Change to window.getClass().getMethod("setStatusBarColor", int.class) will do the trick. And the change also make sure the same behavior as window.setStatusBarColor(colorPref);

### What testing has been done on this change?
Tested on MI 5 device

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
