### PR TITLE
CB-10879: (android) Enable overlaysWebView on Android API 21+

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -142,6 +142,23 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
+        if ("overlaysWebView".equals(action)) {
+            if (Build.VERSION.SDK_INT >= 21) {
+                this.cordova.getActivity().runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            setStatusBarTransparent(args.getBoolean(0));
+                        } catch (JSONException ignore) {
+                            LOG.e(TAG, "Invalid boolean argument");
+                        }
+                    }
+                });
+                return true;
+            }
+            else return args.getBoolean(0) == false;
+        }
+
         return false;
     }
 
@@ -161,6 +178,23 @@ public class StatusBar extends CordovaPlugin {
                     // this should not happen, only in case Android removes this method in a version > 21
                     LOG.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);
                 }
+            }
+        }
+    }
+
+    private void setStatusBarTransparent(final boolean transparent) {
+        if (Build.VERSION.SDK_INT >= 21) {
+            final Window window = cordova.getActivity().getWindow();
+            if (transparent) {
+                window.getDecorView().setSystemUiVisibility(
+                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+                window.setStatusBarColor(Color.TRANSPARENT);
+            }
+            else {
+                window.getDecorView().setSystemUiVisibility(
+                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                | View.SYSTEM_UI_FLAG_VISIBLE);
             }
         }
     }


### PR DESCRIPTION
### Platforms affected

Android (API 21+).

### What does this PR do?

This patch enables devices running Android API 21+ to have the status bar overlaying the WebView, i.e. `StatusBar.overlaysWebView(true)`. It lets any Android version call `StatusBar.overlaysWebView(false)` to disable the overlay, which is actually the default behavior on that platform.

### What testing has been done on this change?

It has been tested on emulators running several android versions, both before and after API 21.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
