### PR TITLE
Browser: Check callback exists before calling it

### DIFF
--- a/src/browser/StatusBarProxy.js
+++ b/src/browser/StatusBarProxy.js
@@ -22,7 +22,9 @@ function notSupported(win,fail) {
     //
     console.log('StatusBar is not supported');
     setTimeout(function(){
-        win();
+        if (win) {
+            win();
+        }
         // note that while it is not explicitly supported, it does not fail
         // this is really just here to allow developers to test their code in the browser
         // and if we fail, then their app might as well. -jm


### PR DESCRIPTION
### Platforms affected
Browser.

### What does this PR do?
Fix exception in Browser platform when calling StatusBar.styleDefault() (The error is: ERROR TypeError: win is not a function).

### What testing has been done on this change?
I Ran it in a browser, and it stopped throwing the exception.

### Checklist
(I think this change is too trivial for the below, but I can do it it if necessary)
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
