### PR TITLE
CB-13124: Add option for native scroll-to-top on WebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Preferences
 
         <preference name="StatusBarStyle" value="lightcontent" />
 
+- __StatusBarDefaultScrollToTop__ (boolean, defaults to false). On iOS 7, allows the Cordova WebView to use default scroll-to-top behavior. Defaults to false so you can listen to the "statusTap" event (described below) and customize the behavior instead.
+
+        <preference name="StatusBarDefaultScrollToTop" value="false" />
+
 ### Android Quirks
 The Android 5+ guidelines specify using a different color for the statusbar than your main app color (unlike the uniform statusbar color of many iOS 7+ apps), so you may want to set the statusbar color at runtime instead via `StatusBar.backgroundColorByHexString` or `StatusBar.backgroundColorByName`. One way to do that would be:
 ```js

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -137,8 +137,14 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         [self setStatusBarStyle:[self settingForKey:setting]];
     }
 
+    setting  = @"StatusBarDefaultScrollToTop";
+    if ([self settingForKey:setting]) {
+        self.webView.scrollView.scrollsToTop = [(NSNumber*)[self settingForKey:setting] boolValue];
+    } else {
+        self.webView.scrollView.scrollsToTop = NO;
+    }
+ 
     // blank scroll view to intercept status bar taps
-    self.webView.scrollView.scrollsToTop = NO;
     UIScrollView *fakeScrollView = [[UIScrollView alloc] initWithFrame:UIScreen.mainScreen.bounds];
     fakeScrollView.delegate = self;
     fakeScrollView.scrollsToTop = YES;


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Adds "StatusBarDefaultScrollToTop" option to allow developer to re-enable native scroll-to-top behavior on the WebView

The motivation for this is described here: https://issues.apache.org/jira/browse/CB-13124
