### PR TITLE
CB-13311: (iOS) Statusbar does not overlay correctly on iPhone X

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -449,6 +449,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 -(void)resizeWebView
 {
     BOOL isIOS7 = (IsAtLeastiOSVersion(@"7.0"));
+    BOOL isIOS11 = (IsAtLeastiOSVersion(@"11.0"));
 
     if (isIOS7) {
         CGRect bounds = [self.viewController.view.window bounds];
@@ -472,8 +473,22 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
                 frame.origin.y = height > 0 ? height: 20;
             }
         } else {
-            // Even if overlay is used, we want to handle in-call/recording/hotspot larger status bar
-            frame.origin.y = height >= 20 ? height - 20 : 0;
+            if (isIOS11) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+                if (@available(iOS 11.0, *)) {
+                    float safeAreaTop = self.webView.safeAreaInsets.top;
+                    if (height >= safeAreaTop && safeAreaTop >0) {
+                        // Sometimes when in-call/recording/hotspot larger status bar is present, the safeAreaTop is 40 but we want frame.origin.y to be 20
+                        frame.origin.y = safeAreaTop == 40 ? 20 : height - safeAreaTop;
+                    } else {
+                        frame.origin.y = 0;
+                    }
+                }
+#endif
+            } else {
+                // Even if overlay is used, we want to handle in-call/recording/hotspot larger status bar
+                frame.origin.y = height >= 20 ? height - 20 : 0;
+            }
         }
         frame.size.height -= frame.origin.y;
         self.webView.frame = frame;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
handle the iPhone X statusbar size when it overlays the webview

### What testing has been done on this change?
tested on iPhone X simulator and also other simulators to make sure it still works fine on them

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
