### PR TITLE
CB-13476 (iOS): handle double size statusbar on SDK 10 for iOS 11

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -217,7 +217,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         rect.size.height = temp;
         rect.origin = CGPointZero;
     }
-    
+
     return rect;
 }
 
@@ -227,7 +227,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     if (!IsAtLeastiOSVersion(@"7.0") || statusBarOverlaysWebView == _statusBarOverlaysWebView) {
         return;
     }
-    
+
     _statusBarOverlaysWebView = statusBarOverlaysWebView;
 
     [self resizeWebView];
@@ -387,7 +387,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
     if (!app.isStatusBarHidden)
     {
-        
+
         [self hideStatusBar];
 
         if (IsAtLeastiOSVersion(@"7.0")) {
@@ -475,6 +475,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         if (!self.statusBarOverlaysWebView) {
             frame.origin.y = height;
         } else {
+            frame.origin.y = height >= 20 ? height - 20 : 0;
             if (isIOS11) {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
                 if (@available(iOS 11.0, *)) {
@@ -487,9 +488,6 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
                     }
                 }
 #endif
-            } else {
-                // Even if overlay is used, we want to handle in-call/recording/hotspot larger status bar
-                frame.origin.y = height >= 20 ? height - 20 : 0;
             }
         }
         frame.size.height -= frame.origin.y;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Handle the double size statusbar for iOS 11 when built with SDK 10

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
