### PR TITLE
CB-13712 (iOS): fix overlaysWebView reset on rotation

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -97,8 +97,12 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
 -(void)statusBarDidChangeFrame:(NSNotification*)notification
 {
-    [self resizeStatusBarBackgroundView];
-    [self resizeWebView];
+    //add a small delay ( 0.1 seconds ) or statusbar size will be wrong
+    __weak CDVStatusBar* weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [weakSelf resizeStatusBarBackgroundView];
+        [weakSelf resizeWebView];
+    });
 }
 
 - (void)pluginInitialize


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Add a small delay we removed so the statusbar size is correct after rotation (it will return 0,0 otherwise) 

### What testing has been done on this change?
Tested on real device

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
