### PR TITLE
Persistent transparency + getStatusBarHeight method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Although in the global scope, it is not available until after the `deviceready` 
 - StatusBar.backgroundColorByHexString
 - StatusBar.hide
 - StatusBar.show
+- StatusBar.getStatusBarHeight (Android only)
 
 Properties
 --------
@@ -284,6 +285,18 @@ StatusBar.show
 Shows the statusbar.
 
     StatusBar.show();
+
+
+StatusBar.getStatusBarHeight
+=================
+
+Gets the current height (in CSS pixels) of system statusbar.
+
+**Note that this is implemented currently only on Android**
+
+    StatusBar.getStatusBarHeight(function(height) {
+        // height in CSS pixels, i.e. 25
+    });
 
 
 Supported Platforms

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -25,6 +25,8 @@ import android.os.Build;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.graphics.Rect;
+import android.content.res.Resources;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
@@ -212,6 +214,17 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
+        if ("getStatusBarHeight".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, getStatusBarHeight()));
+                }
+            });
+            return true;
+        }
+
+
         return false;
     }
 
@@ -283,5 +296,15 @@ public class StatusBar extends CordovaPlugin {
                 LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
             }
         }
+    }
+
+    private int getStatusBarHeight() {
+
+        Rect rectangle = new Rect();
+        Window window = cordova.getActivity().getWindow();
+        window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
+        int statusBarHeight = Math.round(rectangle.top / Resources.getSystem().getDisplayMetrics().density);
+        return statusBarHeight;
+
     }
 }

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -39,6 +39,8 @@ import java.util.Arrays;
 public class StatusBar extends CordovaPlugin {
     private static final String TAG = "StatusBar";
 
+    private boolean transparent = false;
+
     /**
      * Sets the context of the Command. This can then be used to do things like
      * get file paths associated with the Activity.
@@ -61,6 +63,9 @@ public class StatusBar extends CordovaPlugin {
 
                 // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
                 setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
+
+                // Read 'StatusBarOverlaysWebView' from config.xml, default is false.
+                setStatusBarTransparent(preferences.getBoolean("StatusBarOverlaysWebView", false));
 
                 // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
                 setStatusBarStyle(preferences.getString("StatusBarStyle", "lightcontent"));
@@ -96,7 +101,11 @@ public class StatusBar extends CordovaPlugin {
                     // use KitKat here to be aligned with "Fullscreen"  preference
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                         int uiOptions = window.getDecorView().getSystemUiVisibility();
-                        uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                        if (transparent) {
+                            uiOptions |= View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                        } else {
+                            uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                        }
                         uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
 
                         window.getDecorView().setSystemUiVisibility(uiOptions);
@@ -227,20 +236,22 @@ public class StatusBar extends CordovaPlugin {
     }
 
     private void setStatusBarTransparent(final boolean transparent) {
-        if (Build.VERSION.SDK_INT >= 21) {
+        this.transparent = transparent;
             final Window window = cordova.getActivity().getWindow();
             if (transparent) {
                 window.getDecorView().setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                                 | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-                window.setStatusBarColor(Color.TRANSPARENT);
+
+                if (Build.VERSION.SDK_INT >= 21) {
+                    window.setStatusBarColor(Color.TRANSPARENT);
+                }
             }
             else {
                 window.getDecorView().setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                                 | View.SYSTEM_UI_FLAG_VISIBLE);
             }
-        }
     }
 
     private void setStatusBarStyle(final String style) {

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -93,6 +93,13 @@ var StatusBar = {
     show: function () {
         exec(null, null, "StatusBar", "show", []);
         StatusBar.isVisible = true;
+    },
+
+    getStatusBarHeight: function (successCallback, errorCallback) {
+        exec(function (result) {
+            successCallback(result);
+        }, errorCallback, "StatusBar", "getStatusBarHeight", []);
+        StatusBar.isVisible = true;
     }
 
 };


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
1. It makes statusbar transparency persisten. Earlier when you call methods in this order: `overlaysWebView(true)` , `hide()` , `show()` the status bar gets shown without transparency and pushes webview to bottom. And because we wanted to have statusbar transparent (overlaysWebView) from this point the show/hide should toggle the statusbar visibility and it should always show transparent.
2. Support for `StatusBarOverlaysWebView` in Android when its pre-defined in project `config.xml`
3. Added `StatusBar.getStatusBarHeight` method (Android only) that gets current statusbar height in CSS pixels

### What testing has been done on this change?
Manual testing on Android device

