### PR TITLE
Add `getStatusBarHeight` method for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Shows the statusbar.
 
     StatusBar.show();
 
+
 Supported Platforms
 -------------------
 
@@ -305,8 +306,6 @@ StatusBar.getStatusBarHeight
 =================
 
 Gets the current height (in CSS pixels) of system statusbar.
-
-**Note that this is implemented currently only on Android**
 
     StatusBar.getStatusBarHeight(function(height) {
         // height in CSS pixels, i.e. 25

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Although in the global scope, it is not available until after the `deviceready` 
 - StatusBar.backgroundColorByHexString
 - StatusBar.hide
 - StatusBar.show
-- StatusBar.getStatusBarHeight (Android only)
+- StatusBar.getStatusBarHeight
 
 Properties
 --------
@@ -292,6 +292,14 @@ Shows the statusbar.
 
     StatusBar.show();
 
+Supported Platforms
+-------------------
+
+- iOS
+- Android
+- Windows Phone 7
+- Windows Phone 8
+- Windows Phone 8.1
 
 StatusBar.getStatusBarHeight
 =================
@@ -304,16 +312,10 @@ Gets the current height (in CSS pixels) of system statusbar.
         // height in CSS pixels, i.e. 25
     });
 
-
 Supported Platforms
 -------------------
 
-- iOS
 - Android
-- Windows Phone 7
-- Windows Phone 8
-- Windows Phone 8.1
-
 
 StatusBar.isVisible
 =================

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Although in the global scope, it is not available until after the `deviceready` 
 - StatusBar.backgroundColorByHexString
 - StatusBar.hide
 - StatusBar.show
+- StatusBar.getStatusBarHeight (Android only)
 
 Properties
 --------
@@ -290,6 +291,18 @@ StatusBar.show
 Shows the statusbar.
 
     StatusBar.show();
+
+
+StatusBar.getStatusBarHeight
+=================
+
+Gets the current height (in CSS pixels) of system statusbar.
+
+**Note that this is implemented currently only on Android**
+
+    StatusBar.getStatusBarHeight(function(height) {
+        // height in CSS pixels, i.e. 25
+    });
 
 
 Supported Platforms

--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ StatusBar.getStatusBarHeight
 
 Gets the current height (in CSS pixels) of system statusbar.
 
+Note that default Android StatusBar height is setup as `24dp` which in practice means `24px` in WebView. 
+
+This method works well with Android Split Window mode so when app is at the bottom of split view, it returns `0` as the StatusBar height as there is no bar that overlaps app from the top.
+
     StatusBar.getStatusBarHeight(function(height) {
         // height in CSS pixels, i.e. 25
     });

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -25,6 +25,8 @@ import android.os.Build;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
+import android.graphics.Rect;
+import android.content.res.Resources;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
@@ -203,6 +205,17 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
+        if ("getStatusBarHeight".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, getStatusBarHeight()));
+                }
+            });
+            return true;
+        }
+
+
         return false;
     }
 
@@ -272,5 +285,15 @@ public class StatusBar extends CordovaPlugin {
                 LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
             }
         }
+    }
+
+    private int getStatusBarHeight() {
+
+        Rect rectangle = new Rect();
+        Window window = cordova.getActivity().getWindow();
+        window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
+        int statusBarHeight = Math.round(rectangle.top / Resources.getSystem().getDisplayMetrics().density);
+        return statusBarHeight;
+
     }
 }

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -215,7 +215,6 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
-
         return false;
     }
 
@@ -288,7 +287,6 @@ public class StatusBar extends CordovaPlugin {
     }
 
     private int getStatusBarHeight() {
-
         Rect rectangle = new Rect();
         Window window = cordova.getActivity().getWindow();
         window.getDecorView().getWindowVisibleDisplayFrame(rectangle);

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -286,12 +286,26 @@ public class StatusBar extends CordovaPlugin {
         }
     }
 
-    private int getStatusBarHeight() {
+     private int getStatusBarHeight() {
+
+        // Get WebView top offset
         Rect rectangle = new Rect();
         Window window = cordova.getActivity().getWindow();
         window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
-        int statusBarHeight = Math.round(rectangle.top / Resources.getSystem().getDisplayMetrics().density);
+        int webViewTopOffset = Math.round(rectangle.top / Resources.getSystem().getDisplayMetrics().density);
+
+        // Get StatusBar height from resources
+        int statusBarHeight = 0;
+        int resourceId = cordova.getActivity().getResources().getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            statusBarHeight = Math.round(cordova.getActivity().getResources().getDimensionPixelSize(resourceId) / Resources.getSystem().getDisplayMetrics().density);
+        }
+
+        if (webViewTopOffset > statusBarHeight) {
+            // we're in vertical split mode at the bottom so no statusbar overlaying our app
+            return 0;
+        }
         return statusBarHeight;
 
-    }
+     }
 }

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 
 public class StatusBar extends CordovaPlugin {
     private static final String TAG = "StatusBar";
+    private static final int STATUS_BAR_HEIGHT_PX = 24;
 
     /**
      * Sets the context of the Command. This can then be used to do things like
@@ -286,26 +287,19 @@ public class StatusBar extends CordovaPlugin {
         }
     }
 
-     private int getStatusBarHeight() {
+    private int getStatusBarHeight() {
 
         // Get WebView top offset
         Rect rectangle = new Rect();
         Window window = cordova.getActivity().getWindow();
         window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
-        int webViewTopOffset = Math.round(rectangle.top / Resources.getSystem().getDisplayMetrics().density);
+        int webViewTopOffsetPx = Math.round(rectangle.top / Resources.getSystem().getDisplayMetrics().density);
 
-        // Get StatusBar height from resources
-        int statusBarHeight = 0;
-        int resourceId = cordova.getActivity().getResources().getIdentifier("status_bar_height", "dimen", "android");
-        if (resourceId > 0) {
-            statusBarHeight = Math.round(cordova.getActivity().getResources().getDimensionPixelSize(resourceId) / Resources.getSystem().getDisplayMetrics().density);
-        }
-
-        if (webViewTopOffset > statusBarHeight) {
+        if (webViewTopOffsetPx > STATUS_BAR_HEIGHT_PX) {
             // we're in vertical split mode at the bottom so no statusbar overlaying our app
             return 0;
         }
-        return statusBarHeight;
+        return STATUS_BAR_HEIGHT_PX;
 
      }
 }

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -93,6 +93,13 @@ var StatusBar = {
     show: function () {
         exec(null, null, "StatusBar", "show", []);
         StatusBar.isVisible = true;
+    },
+
+    getStatusBarHeight: function (successCallback, errorCallback) {
+        exec(function (result) {
+            successCallback(result);
+        }, errorCallback, "StatusBar", "getStatusBarHeight", []);
+        StatusBar.isVisible = true;
     }
 
 };

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -99,7 +99,6 @@ var StatusBar = {
         exec(function (result) {
             successCallback(result);
         }, errorCallback, "StatusBar", "getStatusBarHeight", []);
-        StatusBar.isVisible = true;
     }
 
 };


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?

Added StatusBar.getStatusBarHeight method (Android only) that gets current statusbar height in CSS pixels

### What testing has been done on this change?
Manual testing on Android device
