### PR TITLE
CB-14238: Make transparency of statusbar persistent when hiding and showing statusbar

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -39,6 +39,8 @@ import java.util.Arrays;
 public class StatusBar extends CordovaPlugin {
     private static final String TAG = "StatusBar";
 
+    private boolean transparent = false;
+
     /**
      * Sets the context of the Command. This can then be used to do things like
      * get file paths associated with the Activity.
@@ -61,6 +63,9 @@ public class StatusBar extends CordovaPlugin {
 
                 // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
                 setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
+
+                // Read 'StatusBarOverlaysWebView' from config.xml, default is false.
+                setStatusBarTransparent(preferences.getBoolean("StatusBarOverlaysWebView", false));
 
                 // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
                 setStatusBarStyle(preferences.getString("StatusBarStyle", "lightcontent"));
@@ -96,7 +101,11 @@ public class StatusBar extends CordovaPlugin {
                     // use KitKat here to be aligned with "Fullscreen"  preference
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                         int uiOptions = window.getDecorView().getSystemUiVisibility();
-                        uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                        if (StatusBar.this.transparent) {
+                            uiOptions |= View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                        } else {
+                            uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                        }
                         uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
 
                         window.getDecorView().setSystemUiVisibility(uiOptions);
@@ -227,19 +236,21 @@ public class StatusBar extends CordovaPlugin {
     }
 
     private void setStatusBarTransparent(final boolean transparent) {
-        if (Build.VERSION.SDK_INT >= 21) {
-            final Window window = cordova.getActivity().getWindow();
-            if (transparent) {
-                window.getDecorView().setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+        this.transparent = transparent;
+        final Window window = cordova.getActivity().getWindow();
+        if (transparent) {
+            window.getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+
+            if (Build.VERSION.SDK_INT >= 21) {
                 window.setStatusBarColor(Color.TRANSPARENT);
             }
-            else {
-                window.getDecorView().setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_VISIBLE);
-            }
+        }
+        else {
+            window.getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_VISIBLE);
         }
     }
 


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
1. It makes statusbar transparency persisten. Earlier when you call methods in this order: `overlaysWebView(true)` , `hide()` , `show()` the status bar gets shown without transparency and pushes webview to bottom. And because we wanted to have statusbar transparent (overlaysWebView) from this point the show/hide should toggle the statusbar visibility and it should always show transparent.
2. Support for `StatusBarOverlaysWebView` in Android when its pre-defined in project `config.xml`

### What testing has been done on this change?
Manual testing on Android device

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.