### PR TITLE
Alpha example doesn't match description

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ if (cordova.platformId == 'android') {
 }
 ```
 
-It is also possible to make the status bar semi-transparent. For example, a black status bar with 20% opacity:
+It is also possible to make the status bar semi-transparent. For example, a black status bar with 33% opacity:
 ```js
 if (cordova.platformId == 'android') {
     StatusBar.overlaysWebView(true);

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ if (cordova.platformId == 'android') {
 }
 ```
 
-It is also possible to make the status bar semi-transparent. For example, a black status bar with 33% opacity:
+It is also possible to make the status bar semi-transparent. Android uses hexadecimal ARGB values, which are formatted as #AARRGGBB. That first pair of letters, the AA, represent the alpha channel. You must convert your decimal opacity values to a hexadecimal value. You can read more about it [here](https://stackoverflow.com/questions/5445085/understanding-colors-on-android-six-characters/11019879#11019879).
+
+For example, a black status bar with 20% opacity:
 ```js
 if (cordova.platformId == 'android') {
     StatusBar.overlaysWebView(true);


### PR DESCRIPTION
if I understand this correctly, "you can also specify values as #AARRGGBB, where AA is an alpha value." The alpha in this example would be 33% right?

`StatusBar.backgroundColorByHexString('#33000000');`

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
