### PR TITLE
Add example configuration on how to hide splash screen on startup on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ Add/edit these two attributes if not present. Set **"Status bar is initially hid
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 
+Or in config.xml inside "platform" block:
+
+
+	<platform name="ios">
+	...
+		<config-file overwrite="true" parent="UIStatusBarHidden" platform="ios" target="*-Info.plist">
+		    <true />
+		</config-file>
+		<config-file overwrite="true" parent="UIViewControllerBasedStatusBarAppearance" platform="ios" target="*-Info.plist">
+		    <false />
+		</config-file>
+	</platform>
+
+
 
 Methods
 -------

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ Or in `config.xml` inside "platform" block:
 
 	<platform name="ios">
 		...
-		<config-file overwrite="true" parent="UIStatusBarHidden" platform="ios" target="*-Info.plist">
+		<config-file overwrite="true" parent="UIStatusBarHidden" target="*-Info.plist">
 		    <true />
 		</config-file>
-		<config-file overwrite="true" parent="UIViewControllerBasedStatusBarAppearance" platform="ios" target="*-Info.plist">
+		<config-file overwrite="true" parent="UIViewControllerBasedStatusBarAppearance" target="*-Info.plist">
 		    <false />
 		</config-file>
 	</platform>

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Add/edit these two attributes if not present. Set **"Status bar is initially hid
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 
-Or in config.xml inside "platform" block:
+Or in `config.xml` inside "platform" block:
 
 
 	<platform name="ios">
-	...
+		...
 		<config-file overwrite="true" parent="UIStatusBarHidden" platform="ios" target="*-Info.plist">
 		    <true />
 		</config-file>


### PR DESCRIPTION
Extend tutorial for hiding at startup. One does not need to directly change Xcode project to hide splash screen. It can be made through config.xml

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
