### PR TITLE
chore: drop Node.js v4 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,10 +12,17 @@ image:
   - Visual Studio 2017
 
 environment:
-  nodejs_version: "6"
+  PLATFORM: windows-10-store
+  JUST_BUILD: --justBuild
   matrix:
-    - PLATFORM: windows-10-store
-      JUST_BUILD: --justBuild
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+
+platform:
+  - x86
+  - x64
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - node --version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,12 +12,12 @@ image:
   - Visual Studio 2017
 
 environment:
-  nodejs_version: "4"
+  nodejs_version: "6"
   matrix:
     - PLATFORM: windows-10-store
       JUST_BUILD: --justBuild
 install:
-  - npm cache clean -f
+  - ps: Install-Product node $env:nodejs_version
   - node --version
   - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
   - npm install -g cordova

--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,3 @@ Thumbs.db
 *.user
 
 node_modules
-
-
-
-
-
-
-
-
- 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TRAVIS_NODE_VERSION=6
 
 language: node_js
-node_js: "6"
+node_js: "$TRAVIS_NODE_VERSION"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,83 +1,90 @@
 sudo: false
+
 addons:
   jwt:
     secure: Rd/wGSUWGWbc0Y/vqPgI29nybq+j/zWilEIOCBJeRQVwfubdbJNZUIb5DFlSSVzMEavkxZ0PYJ45h21iXyWo3aOoxUJwhkO7QZNzW2MsYzy9qpiKK1jOESXMrpboRWoxg+BL85YbaDF3u1XRy+Xm1nraStT6mDfx5LlUG1Lac6A=
+
 env:
   global:
-  - SAUCE_USERNAME=snay
+    - SAUCE_USERNAME=snay
+    - TRAVIS_NODE_VERSION="6"
+
 matrix:
   include:
-  - env: PLATFORM=browser-chrome
-    os: linux
-    language: node_js
-    node_js: '6'
-  - env: PLATFORM=browser-firefox
-    os: linux
-    language: node_js
-    node_js: '6'
-  - env: PLATFORM=browser-safari
-    os: linux
-    language: node_js
-    node_js: '6'
-  - env: PLATFORM=browser-edge
-    os: linux
-    language: node_js
-    node_js: '6'
-  - env: PLATFORM=ios-9.3
-    os: osx
-    osx_image: xcode7.3
-    language: node_js
-    node_js: '6'
-  - env: PLATFORM=ios-10.0
-    os: osx
-    osx_image: xcode7.3
-    language: node_js
-    node_js: '6'
-  - env: PLATFORM=android-4.4
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
-  - env: PLATFORM=android-5.1
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
-  - env: PLATFORM=android-6.0
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
-  - env: PLATFORM=android-7.0
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
+    - env: PLATFORM=browser-chrome
+      os: linux
+      language: node_js
+      node_js: "$TRAVIS_NODE_VERSION"
+    - env: PLATFORM=browser-firefox
+      os: linux
+      language: node_js
+      node_js: "$TRAVIS_NODE_VERSION"
+    - env: PLATFORM=browser-safari
+      os: linux
+      language: node_js
+      node_js: "$TRAVIS_NODE_VERSION"
+    - env: PLATFORM=browser-edge
+      os: linux
+      language: node_js
+      node_js: "$TRAVIS_NODE_VERSION"
+    - env: PLATFORM=ios-9.3
+      os: osx
+      osx_image: xcode7.3
+      language: node_js
+      node_js: "$TRAVIS_NODE_VERSION"
+    - env: PLATFORM=ios-10.0
+      os: osx
+      osx_image: xcode7.3
+      language: node_js
+      node_js: "$TRAVIS_NODE_VERSION"
+    - env: PLATFORM=android-4.4
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+          - tools
+          - build-tools-26.0.2
+    - env: PLATFORM=android-5.1
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+          - tools
+          - build-tools-26.0.2
+    - env: PLATFORM=android-6.0
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+          - tools
+          - build-tools-26.0.2
+    - env: PLATFORM=android-7.0
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+          - tools
+          - build-tools-26.0.2
+
 before_install:
-- if [[ "$PLATFORM" =~ android ]]; then nvm install 6; fi
-- node --version
-- if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
-- if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
-- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27;
-  fi
-- git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic
-  && npm install && popd
-- npm install -g cordova
+  # language: android has no Node.js installed, therfore it's needed to install it manually
+  - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi
+  - node --version
+  - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
+  - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
+  - if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27;
+    fi
+  - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
+  - npm install -g cordova
+
 install:
-- npm install
+  - npm install
+
 script:
-- npm test
-- node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
-  --buildName travis-plugin-statusbar-$TRAVIS_JOB_NUMBER
+  - npm test
+  - node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
+    --buildName travis-plugin-statusbar-$TRAVIS_JOB_NUMBER

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     - TRAVIS_NODE_VERSION=6
 
 language: node_js
-node_js: "$TRAVIS_NODE_VERSION"
+node_js: 6
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
           - build-tools-26.0.2
 
 before_install:
-  # language: android has no Node.js installed, therfore it's needed to install it manually
+  # `language: android` has no Node.js installed, therefore we need to install it manually
   - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi
   - node --version
   - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,35 +5,34 @@ addons:
 env:
   global:
   - SAUCE_USERNAME=snay
-  - TRAVIS_NODE_VERSION="4.2"
 matrix:
   include:
   - env: PLATFORM=browser-chrome
     os: linux
     language: node_js
-    node_js: '4.2'
+    node_js: '6'
   - env: PLATFORM=browser-firefox
     os: linux
     language: node_js
-    node_js: '4.2'
+    node_js: '6'
   - env: PLATFORM=browser-safari
     os: linux
     language: node_js
-    node_js: '4.2'
+    node_js: '6'
   - env: PLATFORM=browser-edge
     os: linux
     language: node_js
-    node_js: '4.2'
+    node_js: '6'
   - env: PLATFORM=ios-9.3
     os: osx
     osx_image: xcode7.3
     language: node_js
-    node_js: '4.2'
+    node_js: '6'
   - env: PLATFORM=ios-10.0
     os: osx
     osx_image: xcode7.3
     language: node_js
-    node_js: '4.2'
+    node_js: '6'
   - env: PLATFORM=android-4.4
     os: linux
     language: android
@@ -67,9 +66,7 @@ matrix:
       - tools
       - build-tools-26.0.2
 before_install:
-- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
-  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
-  install $TRAVIS_NODE_VERSION
+- if [[ "$PLATFORM" =~ android ]]; then nvm install 6; fi
 - node --version
 - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
 - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,4 +68,4 @@ install:
 
 script:
   - npm test
-  - cordova-paramedic --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce --buildName travis-plugin-statusbar-$TRAVIS_JOB_NUMBER
+  - cordova-paramedic --config pr/$PLATFORM --plugin $TRAVIS_BUILD_DIR --shouldUseSauce --buildName travis-$TRAVIS_REPO_SLUG-$TRAVIS_JOB_NUMBER

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,38 +7,24 @@ addons:
 env:
   global:
     - SAUCE_USERNAME=snay
-    - TRAVIS_NODE_VERSION="6"
+    - TRAVIS_NODE_VERSION=6
+
+language: node_js
+node_js: "6"
 
 matrix:
   include:
     - env: PLATFORM=browser-chrome
-      os: linux
-      language: node_js
-      node_js: "$TRAVIS_NODE_VERSION"
     - env: PLATFORM=browser-firefox
-      os: linux
-      language: node_js
-      node_js: "$TRAVIS_NODE_VERSION"
     - env: PLATFORM=browser-safari
-      os: linux
-      language: node_js
-      node_js: "$TRAVIS_NODE_VERSION"
     - env: PLATFORM=browser-edge
-      os: linux
-      language: node_js
-      node_js: "$TRAVIS_NODE_VERSION"
     - env: PLATFORM=ios-9.3
       os: osx
       osx_image: xcode7.3
-      language: node_js
-      node_js: "$TRAVIS_NODE_VERSION"
     - env: PLATFORM=ios-10.0
       os: osx
       osx_image: xcode7.3
-      language: node_js
-      node_js: "$TRAVIS_NODE_VERSION"
     - env: PLATFORM=android-4.4
-      os: linux
       language: android
       jdk: oraclejdk8
       android:
@@ -46,7 +32,6 @@ matrix:
           - tools
           - build-tools-26.0.2
     - env: PLATFORM=android-5.1
-      os: linux
       language: android
       jdk: oraclejdk8
       android:
@@ -54,7 +39,6 @@ matrix:
           - tools
           - build-tools-26.0.2
     - env: PLATFORM=android-6.0
-      os: linux
       language: android
       jdk: oraclejdk8
       android:
@@ -62,7 +46,6 @@ matrix:
           - tools
           - build-tools-26.0.2
     - env: PLATFORM=android-7.0
-      os: linux
       language: android
       jdk: oraclejdk8
       android:
@@ -76,8 +59,7 @@ before_install:
   - node --version
   - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
   - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
-  - if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27;
-    fi
+  - if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27; fi
   - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
   - npm install -g cordova
 
@@ -86,5 +68,4 @@ install:
 
 script:
   - npm test
-  - node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
-    --buildName travis-plugin-statusbar-$TRAVIS_JOB_NUMBER
+  - cordova-paramedic --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce --buildName travis-plugin-statusbar-$TRAVIS_JOB_NUMBER


### PR DESCRIPTION
This is a BREAKING CHANGE.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a - development

### What does this PR do?

Drop Node.js v4 support and bumps the CI images to Node.js v6

### What testing has been done on this change?

TravisCI and Appveyor test results.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
