### PR TITLE
feat: get statusbar height (top-inset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,27 @@ Supported Platforms
 - Android
 - Windows
 
+StatusBar.height
+=================
+
+Call this function to get the height of the statusbar.
+
+    StatusBar.height(onSuccess, onError);
+
+    const onSuccess = (height) => {
+        // do something with the statusbar height here
+    }
+
+    const onError = (error) => {
+        // handle error state; should usually not ever activate
+    }
+    
+Supported Platforms
+-------------------
+
+- iOS
+- Android
+
 statusTap
 =========
 

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -95,6 +95,12 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
+        if ("height".equals(action)) {
+            float statusBarHeight = getStatusBarHeight();
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, statusBarHeight));
+            return true;
+        }
+
         if ("show".equals(action)) {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -211,6 +217,16 @@ public class StatusBar extends CordovaPlugin {
         }
 
         return false;
+    }
+
+    private float getStatusBarHeight() {
+        float statusBarHeight = 0;
+        int resourceId = cordova.getActivity().getResources().getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            float scaleRatio = cordova.getActivity().getResources().getDisplayMetrics().density;
+            statusBarHeight = cordova.getActivity().getResources().getDimension(resourceId) / scaleRatio;
+        }
+        return statusBarHeight;
     }
 
     private void setStatusBarBackgroundColor(final String colorPref) {

--- a/src/browser/StatusBarProxy.js
+++ b/src/browser/StatusBarProxy.js
@@ -41,6 +41,7 @@ module.exports = {
     styleLightContect: notSupported,
     backgroundColorByName: notSupported,
     backgroundColorByHexString: notSupported,
+    height: 0,
     hide: notSupported,
     show: notSupported,
     _ready: notSupported

--- a/src/ios/CDVStatusBar.h
+++ b/src/ios/CDVStatusBar.h
@@ -44,6 +44,8 @@
 
 - (void) hide:(CDVInvokedUrlCommand*)command;
 - (void) show:(CDVInvokedUrlCommand*)command;
+
+- (void) height:(CDVInvokedUrlCommand*)command;
     
 - (void) _ready:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -199,6 +199,14 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     }
 }
 
+- (void) height:(CDVInvokedUrlCommand*)command
+{
+    double statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:statusBarHeight];
+    [result setKeepCallbackAsBool:YES];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
 - (void) initializeStatusBarBackgroundView
 {
     CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -59,6 +59,11 @@ exports.defineAutoTests = function () {
             expect(window.StatusBar.overlaysWebView).toBeDefined();
             expect(typeof window.StatusBar.overlaysWebView).toBe('function');
         });
+
+        it('statusbar.spec.5 should have get height method', function () {
+            expect(window.StatusBar.height).toBeDefined();
+            expect(typeof window.StatusBar.height).toBe('function');
+        });
     });
 };
 
@@ -100,6 +105,18 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         showOverlay = !showOverlay;
         StatusBar.overlaysWebView(showOverlay);
         log('Set overlay=' + showOverlay);
+    }
+
+    function onGetHeightSuccess (height) {
+        log('Got our status bar height as ' + height + 'px');
+    }
+
+    function onGetHeightError (error) {
+        log('Our height call failed with the error logs: ' + error);
+    }
+
+    function getStatusBarHeight () {
+        StatusBar.height(onGetHeightSuccess, onGetHeightError);
     }
 
     /******************************************************************************/
@@ -176,4 +193,6 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         },
         'action-overlays'
     );
+
+    getStatusBarHeight();
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,6 +63,11 @@ interface StatusBar {
     backgroundColorByHexString(color: string): void;
 
     /**
+     * Get the statusbar's height
+     */
+    height(onSuccess: (height: number) => void, onError?: (error: any) => void): void;
+
+    /**
     * Hide the statusbar.
     */
     hide(): void;

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -84,6 +84,10 @@ var StatusBar = {
         exec(null, null, 'StatusBar', 'backgroundColorByHexString', [hexString]);
     },
 
+    height: function (onSuccess, onError) {
+        exec(onSuccess, onError, 'StatusBar', 'height', []);
+    },
+
     hide: function () {
         exec(null, null, 'StatusBar', 'hide', []);
         StatusBar.isVisible = false;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
The main platform that this is desired for is Android. But this enhancement works on iOS as well.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This adds a function that allows us to get the height of the status bar. This is inspired from this issue https://github.com/ionic-team/ionic/issues/17927 where the safe-inset paramters are not respected for Android devices so there is no way to get the statusbar height to enable appropriate styles to support app overlays.

This resolves #112 .


### Testing
<!-- Please describe in detail how you tested your changes. -->
With testing, the current android implementation AND iOS implementation along with the javascript bridge is working as intended! On an iPhone X, we get a value of 44px as intended. And on an android phone with and without a notch, we get the respective heights of statusbar. Required tests have been added.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
