### PR TITLE
fix(iOS): Delay resizeWebView on viewWillAppear for correct statusbar height

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -92,7 +92,11 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
 -(void)cordovaViewWillAppear:(NSNotification*)notification
 {
-    [self resizeWebView];
+    //add a small delay ( 0.1 seconds ) or statusbar size will be wrong
+    __weak CDVStatusBar* weakSelf = self;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [weakSelf resizeWebView];
+    });
 }
 
 -(void)statusBarDidChangeFrame:(NSNotification*)notification


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
* iOS (13)


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
* On iOS 13 the height of the statusbar is set 0 when returning from the camera for example.



### Description
<!-- Describe your changes in detail -->
* I delayed the call of `resizeWebView` in `cordovaViewWillAppear` by 0.1 seconds according to `statusBarDidChangeFrame`.



### Testing
<!-- Please describe in detail how you tested your changes. -->
* When `resizeWebView` was called to early on resume from the background or the camera for example `statusBarFrame.size.height` was 0. After my changes it was correct in this scenario.

closes https://github.com/apache/cordova-plugin-statusbar/issues/156

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- I've updated the documentation if necessary
