### PR TITLE
fix(ios): make default set black text on iOS 13 too

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -294,7 +294,12 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
 - (void) styleDefault:(CDVInvokedUrlCommand*)command
 {
-    [self setStyleForStatusBar:UIStatusBarStyleDefault];
+    if (@available(iOS 13.0, *)) {
+        // TODO - Replace with UIStatusBarStyleDarkContent once Xcode 10 support is dropped
+        [self setStyleForStatusBar:3];
+    } else {
+        [self setStyleForStatusBar:UIStatusBarStyleDefault];
+    }
 }
 
 - (void) styleLightContent:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION

### Platforms affected
ios


### Motivation and Context
Closes #148 


### Description
on iOS 13, default depends on the device mode.
This PR forces default to always black.

### Testing
Tested on iOS 13 device and iOS 11 device on Xcode 10 and 11

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
