### PR TITLE
[do not merge yet](android) Read config.xml for statusbar overlay preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Preferences
     
     Only supported on Android 5 or later. Earlier versions will ignore this preference.
 
-- __StatusBarBackgroundColor__ (color hex string, no default value). Set the background color of the statusbar by a hex string (#RRGGBB) at startup. If this value is not set, the background color will be transparent.
+- __StatusBarBackgroundColor__ (color hex string, no default value). Set the background color of the statusbar by a hex string (#RRGGBB) at startup. If this value is not set, the background color will be transparent. If `StatusBarOverlaysWebView` is set to true, then a 8 digit hex (#AARRGGBB) string can optionally be used to define the transparency.
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,7 @@
                 <param name="android-package" value="org.apache.cordova.statusbar.StatusBar" />
                 <param name="onload" value="true" />
             </feature>
+            <preference name="StatusBarOverlaysWebView" value="true" />
         </config-file>
     </platform>
 

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -59,6 +59,9 @@ public class StatusBar extends CordovaPlugin {
                 Window window = cordova.getActivity().getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 
+                // Read 'StatusBarOverlaysWebView' from config.xml, default is true.
+                setStatusBarTransparent(preferences.getBoolean("StatusBarOverlaysWebView", true));
+
                 // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
                 setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Android never read from `config.xml` for the `StatusBarOverlaysWebView` preference. This PR fixes it so that it reads the preference value, or defaults to true (as dictated by the current documentation)
Fixes #170 
Fixes #151 

### Description
<!-- Describe your changes in detail -->
Above is pretty much my changes.
There is an existing PR that also addresses this issue at https://github.com/apache/cordova-plugin-statusbar/pull/142 but hasn't had activity since June and hasn't responded to change requests. This PR corrects the issue, with requested changes in mind.

Technically this is a breaking change... as android never obeyed the `StatusBarOverlaysWebView` preference or its defaults, the android default will go from solid statusbar to an overlayed statusbar.

### Testing
<!-- Please describe in detail how you tested your changes. -->
`npm test` and manual testing


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
