### PR TITLE
deprecate blacktranslucent, blackopaque, styleBlackTranslucent and styleBlackOpaque

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ description: Control the device status bar.
 This installation method requires cordova 5.0+
 
     cordova plugin add cordova-plugin-statusbar
-Older versions of cordova can still install via the __deprecated__ id
 
-    cordova plugin add org.apache.cordova.statusbar
 It is also possible to install via repo url directly ( unstable )
 
     cordova plugin add https://github.com/apache/cordova-plugin-statusbar.git
@@ -59,7 +57,7 @@ Preferences
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 
-- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: default, lightcontent, blacktranslucent, blackopaque.
+- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: `default`, `lightcontent`. `blacktranslucent` and `blackopaque` are also available, but __deprecated__, will be removed in next major release, use `lightcontent` instead.
 
         <preference name="StatusBarStyle" value="lightcontent" />
 
@@ -197,6 +195,8 @@ Supported Platforms
 StatusBar.styleBlackTranslucent
 =================
 
+Note: `styleBlackTranslucent` is __deprecated__ and will be removed in next major release, use `styleLightContent` instead.
+
 Use the blackTranslucent statusbar (light text, for dark backgrounds).
 
     StatusBar.styleBlackTranslucent();
@@ -211,6 +211,8 @@ Supported Platforms
 
 StatusBar.styleBlackOpaque
 =================
+
+Note: `styleBlackOpaque` is __deprecated__ and will be removed in next major release, use `styleLightContent` instead.
 
 Use the blackOpaque statusbar (light text, for dark backgrounds).
 

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -63,7 +63,11 @@ public class StatusBar extends CordovaPlugin {
                 setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
 
                 // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
-                setStatusBarStyle(preferences.getString("StatusBarStyle", "lightcontent"));
+                String styleSetting = preferences.getString("StatusBarStyle", "lightcontent");
+                if (styleSetting.equalsIgnoreCase("blacktranslucent") || styleSetting.equalsIgnoreCase("blackopaque")) {
+                    LOG.w(TAG, styleSetting +" is deprecated and will be removed in next major release, use lightcontent");
+                }
+                setStatusBarStyle(styleSetting);
             }
         });
     }

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -137,7 +137,11 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
     setting  = @"StatusBarStyle";
     if ([self settingForKey:setting]) {
-        [self setStatusBarStyle:[self settingForKey:setting]];
+        NSString * styleSetting = [self settingForKey:setting];
+        if ([styleSetting isEqualToString:@"blacktranslucent"] || [styleSetting isEqualToString:@"blackopaque"]) {
+            NSLog(@"%@ is deprecated and will be removed in next major release, use lightcontent", styleSetting);
+        }
+        [self setStatusBarStyle:styleSetting];
     }
 
     setting  = @"StatusBarDefaultScrollToTop";

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -59,12 +59,12 @@ var StatusBar = {
     },
 
     styleBlackTranslucent: function () {
-        // #88000000 ? Apple says to use lightContent instead
+        console.warn('styleBlackTranslucent is deprecated and will be removed in next major release, use styleLightContent');
         exec(null, null, "StatusBar", "styleBlackTranslucent", []);
     },
 
     styleBlackOpaque: function () {
-        // #FF000000 ? Apple says to use lightContent instead
+        console.warn('styleBlackOpaque is deprecated and will be removed in next major release, use styleLightContent')
         exec(null, null, "StatusBar", "styleBlackOpaque", []);
     },
 

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -64,7 +64,7 @@ var StatusBar = {
     },
 
     styleBlackOpaque: function () {
-        console.warn('styleBlackOpaque is deprecated and will be removed in next major release, use styleLightContent')
+        console.warn('styleBlackOpaque is deprecated and will be removed in next major release, use styleLightContent');
         exec(null, null, "StatusBar", "styleBlackOpaque", []);
     },
 


### PR DESCRIPTION
Deprecates `blacktranslucent` and `blackopaque` values from `StatusBarStyle` preference, showing a native warning message if set.

Also deprecates `styleBlackTranslucent` and `styleBlackOpaque` functions, showing a javascript warning if used.

Finally, it documents in the README that the preference values and methods are deprecated.


closes #163 