### PR TITLE
Add new styleDarkContent with possibility of selection of default style that is very important for iOS (#164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Although in the global scope, it is not available until after the `deviceready` 
 - StatusBar.overlaysWebView
 - StatusBar.styleDefault
 - StatusBar.styleLightContent
+- StatusBar.styleDarkContent
 - StatusBar.styleBlackTranslucent
 - StatusBar.styleBlackOpaque
 - StatusBar.backgroundColorByName
@@ -168,6 +169,7 @@ StatusBar.styleDefault
 =================
 
 Use the default statusbar (dark text, for light backgrounds).
+For iOS - dark or light text depending on current device theme.
 
     StatusBar.styleDefault();
 
@@ -185,6 +187,21 @@ StatusBar.styleLightContent
 Use the lightContent statusbar (light text, for dark backgrounds).
 
     StatusBar.styleLightContent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Android 6+
+- Windows
+
+StatusBar.styleDarkContent
+=================
+
+Use the darkContent statusbar (dark text, for light backgrounds).
+
+    StatusBar.styleDarkContent();
 
 
 Supported Platforms

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Preferences
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 
-- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: default, lightcontent, blacktranslucent, blackopaque.
+- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: default, lightcontent, darkcontent, blacktranslucent, blackopaque.
 
         <preference name="StatusBarStyle" value="lightcontent" />
 
@@ -169,7 +169,7 @@ StatusBar.styleDefault
 =================
 
 Use the default statusbar (dark text, for light backgrounds).
-For iOS - dark or light text depending on current device theme.
+For iOS - dark or light text depending on a device current theme.
 
     StatusBar.styleDefault();
 

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -183,6 +183,16 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
+        if ("styleDarkContent".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    setStatusBarStyle("darkcontent");
+                }
+            });
+            return true;
+        }
+
         if ("styleBlackTranslucent".equals(action)) {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -251,6 +261,7 @@ public class StatusBar extends CordovaPlugin {
 
                 String[] darkContentStyles = {
                     "default",
+                    "darkcontent"
                 };
 
                 String[] lightContentStyles = {
@@ -269,7 +280,7 @@ public class StatusBar extends CordovaPlugin {
                     return;
                 }
 
-                LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
+                LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent', 'darkcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
             }
         }
     }

--- a/src/browser/StatusBarProxy.js
+++ b/src/browser/StatusBarProxy.js
@@ -36,6 +36,7 @@ module.exports = {
     styleBlackTranslucent:notSupported,
     styleDefault:notSupported,
     styleLightContent:notSupported,
+    styleDarkContent: notSupported,
     styleBlackOpaque:notSupported,
     overlaysWebView:notSupported,
     styleLightContect: notSupported,

--- a/src/ios/CDVStatusBar.h
+++ b/src/ios/CDVStatusBar.h
@@ -36,6 +36,7 @@
 
 - (void) styleDefault:(CDVInvokedUrlCommand*)command;
 - (void) styleLightContent:(CDVInvokedUrlCommand*)command;
+- (void) styleDarkContent:(CDVInvokedUrlCommand*)command;
 - (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command;
 - (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -311,7 +311,8 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 - (void) styleDarkContent:(CDVInvokedUrlCommand*)command
 {
     if (@available(iOS 13.0, *)) {
-        [self setStyleForStatusBar:UIStatusBarStyleDarkContent];
+        // [self setStyleForStatusBar:UIStatusBarStyleDarkContent];
+        [self setStyleForStatusBar:3];
     } else {
         [self styleDefault: command];
     }

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -285,6 +285,8 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         [self styleDefault:nil];
     } else if ([lcStatusBarStyle isEqualToString:@"lightcontent"]) {
         [self styleLightContent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"darkcontent"]) {
+        [self styleDarkContent:nil];
     } else if ([lcStatusBarStyle isEqualToString:@"blacktranslucent"]) {
         [self styleBlackTranslucent:nil];
     } else if ([lcStatusBarStyle isEqualToString:@"blackopaque"]) {

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -294,17 +294,21 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
 - (void) styleDefault:(CDVInvokedUrlCommand*)command
 {
-    if (@available(iOS 13.0, *)) {
-        // TODO - Replace with UIStatusBarStyleDarkContent once Xcode 10 support is dropped
-        [self setStyleForStatusBar:3];
-    } else {
-        [self setStyleForStatusBar:UIStatusBarStyleDefault];
-    }
+    [self setStyleForStatusBar:UIStatusBarStyleDefault];
 }
 
 - (void) styleLightContent:(CDVInvokedUrlCommand*)command
 {
     [self setStyleForStatusBar:UIStatusBarStyleLightContent];
+}
+
+- (void) styleDarkContent:(CDVInvokedUrlCommand*)command
+{
+    if (@available(iOS 13.0, *)) {
+        [self setStyleForStatusBar:UIStatusBarStyleDarkContent];
+    } else {
+        [self styleDefault: command];
+    }
 }
 
 - (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command

--- a/src/windows/StatusBarProxy.js
+++ b/src/windows/StatusBarProxy.js
@@ -78,6 +78,13 @@ module.exports = {
         }
     },
 
+    styleDarkContent: function () {
+        // dark text ( to be used on a light background )
+        if (isSupported()) {
+            getViewStatusBar().foregroundColor = { a: 0, r: 0, g: 0, b: 0 };
+        }
+    },
+
     styleBlackTranslucent: function () {
         // #88000000 ? Apple says to use lightContent instead
         return module.exports.styleLightContent();

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -54,6 +54,9 @@ exports.defineAutoTests = function () {
             expect(window.StatusBar.styleLightContent).toBeDefined();
             expect(typeof window.StatusBar.styleLightContent).toBe("function");
 
+            expect(window.StatusBar.styleDarkContent).toBeDefined();
+            expect(typeof window.StatusBar.styleDarkContent).toBe("function");
+
             expect(window.StatusBar.styleBlackOpaque).toBeDefined();
             expect(typeof window.StatusBar.styleBlackOpaque).toBe("function");
 
@@ -96,6 +99,11 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         StatusBar.styleDefault();
     }
 
+    function doColor4() {
+        log('set style=dark');
+        StatusBar.styleDarkContent();
+    }
+
     var showOverlay = true;
     function doOverlay() {
         showOverlay = !showOverlay;
@@ -114,6 +122,8 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '</p> <div id="action-color2"></div>' +
         'Expected result: Status bar text will be a light (white) color' +
         '</p> <div id="action-color3"></div>' +
+        'Expected result: Status bar text will be a dark (black) color<br>for iOS - a device theme depending (black or white) color' +
+        '</p> <div id="action-color4"></div>' +
         'Expected result: Status bar text will be a dark (black) color' +
         '</p> <div id="action-overlays"></div>' +
         'Expected result:<br>Overlay true = status bar will lay on top of web view content<br>Overlay false = status bar will be separate from web view and will not cover content' +
@@ -144,6 +154,10 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton("Style=default", function () {
         doColor3();
     }, 'action-color3');
+
+    createActionButton("Style=dark", function () {
+        doColor4();
+    }, 'action-color4');
 
     createActionButton("Toggle Overlays", function () {
         doOverlay();

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -100,7 +100,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     }
 
     function doColor4() {
-        log('set style=dark');
+        log('set style=darkcontent');
         StatusBar.styleDarkContent();
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ interface StatusBar {
 
     /**
     * Use the default statusbar (dark text, for light backgrounds).
+    * For iOS - dark or light text depending on a device configuration.
     */
     styleDefault(): void;
 
@@ -33,6 +34,11 @@ interface StatusBar {
     * Use the lightContent statusbar (light text, for dark backgrounds).
     */
     styleLightContent(): void;
+
+    /**
+     * Use the darkContent statusbar (dark text, for light backgrounds).
+     */
+    styleDarkContent(): void;
 
     /**
     * Use the blackTranslucent statusbar (light text, for dark backgrounds).

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -49,13 +49,18 @@ var StatusBar = {
     },
 
     styleDefault: function () {
-        // dark text ( to be used on a light background )
+        // dark text ( to be used on a light background and on iOS depending on a device configuration )
         exec(null, null, "StatusBar", "styleDefault", []);
     },
 
     styleLightContent: function () {
         // light text ( to be used on a dark background )
         exec(null, null, "StatusBar", "styleLightContent", []);
+    },
+
+    styleDarkContent: function () {
+        // dark text ( to be used on a light background )
+        exec(null, null, "StatusBar", "styleDarkContent", []);
     },
 
     styleBlackTranslucent: function () {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All platforms, especially iOS.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #164. Fixes #162.
It has been already fixed but not completely correctly. iOS statusbar has different behaviour for Default and Dark styles.


### Description
<!-- Describe your changes in detail -->

Added styleDarkContent similar to styleLightContent

### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested on iPhone SE with iOS 13, Android emulator SDK 29.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
