### PR TITLE
ci: add gh-actions workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Android Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Android Latest Test
+    runs-on: macos-latest
+
+    # hoist configurations to top that are expected to be updated
+    env:
+      node-version: 16
+      cordova-version: '10.0.0'
+      cordova-paramedic-npmsource: 'apache/cordova-paramedic'
+      java-version: 11
+      java-distro: 'adopt'
+      android-api: 30
+
+    strategy:
+      matrix:
+        versions:
+          - cordova-android: '10.1.0'
+
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node-version }}
+      - uses: actions/setup-java@v2
+        with:
+          distribution: ${{ env.java-distro }}
+          java-version: ${{ env.java-version }}
+
+      - name: Run Environment Information
+        run: |
+          node --version
+          npm --version
+          java -version
+
+      - name: Run npm install
+        run: |
+          export PATH="/usr/local/lib/android/sdk/platform-tools":$PATH
+          export JAVA_HOME=$JAVA_HOME_11_X64
+          npm i -g cordova@${{ env.cordova-version }}
+          npm i -g ${{ env.cordova-paramedic-npmsource }}
+          npm ci
+
+      - uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.android-api }}
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          disable-animations: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          script: echo "Pregenerate the AVD before running Paramedic"
+
+      - name: Run paramedic tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.android-api }}
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          disable-animations: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          script: cordova-paramedic --platform android@${{ matrix.versions.cordova-android }} --plugin .

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,7 +64,7 @@ jobs:
           npm i -g ${{ env.cordova-paramedic-npmsource }}
           npm ci
 
-      - uses: reactivecircus/android-emulator-runner@v2
+      - uses: reactivecircus/android-emulator-runner@5de26e4bd23bf523e8a4b7f077df8bfb8e52b50e
         with:
           api-level: ${{ env.android-api }}
           target: google_apis
@@ -75,7 +75,7 @@ jobs:
           script: echo "Pregenerate the AVD before running Paramedic"
 
       - name: Run paramedic tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@5de26e4bd23bf523e8a4b7f077df8bfb8e52b50e
         with:
           api-level: ${{ env.android-api }}
           target: google_apis

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: iOS Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: iOS
+    runs-on: macos-latest
+
+    # hoist configurations to top that are expected to be updated
+    env:
+      node-version: 14
+      cordova-version: '10.0.0'
+      cordova-paramedic-npmsource: 'apache/cordova-paramedic'
+
+    strategy:
+      matrix:
+        versions:
+          - cordova-ios: '6.2.0'
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.node-version }}
+
+      - name: Environment Information
+        run: |
+          node --version
+          npm --version
+
+      - name: npm install
+        run: |
+          npm i -g cordova@${{ env.cordova-version }}
+          npm i -g ${{ env.cordova-paramedic-npmsource }}
+          npm i -g ios-deploy
+          npm ci
+
+      - name: test with cordova-paramedic
+        run: |
+          cordova-paramedic --platform ios@${{ matrix.versions.cordova-ios }} --plugin .


### PR DESCRIPTION
### Platforms affected
- CI: ios & android


### Motivation and Context
Add GH Actions to run plugin tests using `cordova-paramedic`

- Android: https://github.com/SwitchCaseGroup/cordova-plugin-statusbar/actions/runs/1192373245
- iOS: https://github.com/SwitchCaseGroup/cordova-plugin-statusbar/actions/runs/1192373244

### Description
Adding two new workflows.
- Trying to follow workflows in existing apache repo https://github.com/apache/cordova-paramedic/pull/215

### Testing
Tests can be verified by viewing workflow results
- Android: https://github.com/SwitchCaseGroup/cordova-plugin-statusbar/actions/runs/1192373245
- iOS: https://github.com/SwitchCaseGroup/cordova-plugin-statusbar/actions/runs/1192373244



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
