### PR TITLE
chore(ios): Silence/fix warnings

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -272,11 +272,14 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 {
     if (_uiviewControllerBasedStatusBarAppearance) {
         CDVViewController* vc = (CDVViewController*)self.viewController;
-        vc.sb_statusBarStyle = [NSNumber numberWithInt:style];
+        vc.sb_statusBarStyle = [NSNumber numberWithInt:(int)style];
         [self refreshStatusBarAppearance];
 
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [[UIApplication sharedApplication] setStatusBarStyle:style];
+#pragma clang diagnostic pop
     }
 }
 
@@ -368,7 +371,10 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
     } else {
         UIApplication* app = [UIApplication sharedApplication];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [app setStatusBarHidden:YES];
+#pragma clang diagnostic pop
     }
 }
 
@@ -399,7 +405,10 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
     } else {
         UIApplication* app = [UIApplication sharedApplication];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [app setStatusBarHidden:NO];
+#pragma clang diagnostic pop
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
silences and fixes warnings in code

closes https://github.com/apache/cordova-plugin-statusbar/issues/215

### Description
silences deprecation warnings since the code still works (tested on iOS 15) and is only used if `UIViewControllerBasedStatusBarAppearance` is present in the Info.plist and with `NO` value. 


### Testing
real device and simulator


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
