### PR TITLE
chore!: remove deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Preferences
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 
-- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: `default`, `lightcontent`. `blacktranslucent` and `blackopaque` are also available, but __deprecated__, will be removed in next major release, use `lightcontent` instead.
+- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: `default`, `lightcontent`.
 
         <preference name="StatusBarStyle" value="lightcontent" />
 
@@ -118,8 +118,6 @@ Although in the global scope, it is not available until after the `deviceready` 
 - StatusBar.overlaysWebView
 - StatusBar.styleDefault
 - StatusBar.styleLightContent
-- StatusBar.styleBlackTranslucent
-- StatusBar.styleBlackOpaque
 - StatusBar.backgroundColorByName
 - StatusBar.backgroundColorByHexString
 - StatusBar.hide
@@ -189,41 +187,6 @@ Supported Platforms
 - iOS
 - Android 6+
 - Windows
-
-StatusBar.styleBlackTranslucent
-=================
-
-Note: `styleBlackTranslucent` is __deprecated__ and will be removed in next major release, use `styleLightContent` instead.
-
-Use the blackTranslucent statusbar (light text, for dark backgrounds).
-
-    StatusBar.styleBlackTranslucent();
-
-
-Supported Platforms
--------------------
-
-- iOS
-- Android 6+
-- Windows
-
-StatusBar.styleBlackOpaque
-=================
-
-Note: `styleBlackOpaque` is __deprecated__ and will be removed in next major release, use `styleLightContent` instead.
-
-Use the blackOpaque statusbar (light text, for dark backgrounds).
-
-    StatusBar.styleBlackOpaque();
-
-
-Supported Platforms
--------------------
-
-- iOS
-- Android 6+
-- Windows
-
 
 StatusBar.backgroundColorByName
 =================

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -67,9 +67,6 @@ public class StatusBar extends CordovaPlugin {
 
                 // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
                 String styleSetting = preferences.getString("StatusBarStyle", "lightcontent");
-                if (styleSetting.equalsIgnoreCase("blacktranslucent") || styleSetting.equalsIgnoreCase("blackopaque")) {
-                    LOG.w(TAG, styleSetting +" is deprecated and will be removed in next major release, use lightcontent");
-                }
                 setStatusBarStyle(styleSetting);
             }
         });
@@ -190,26 +187,6 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
-        if ("styleBlackTranslucent".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("blacktranslucent");
-                }
-            });
-            return true;
-        }
-
-        if ("styleBlackOpaque".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("blackopaque");
-                }
-            });
-            return true;
-        }
-
         return false;
     }
 
@@ -262,8 +239,6 @@ public class StatusBar extends CordovaPlugin {
 
                 String[] lightContentStyles = {
                     "lightcontent",
-                    "blacktranslucent",
-                    "blackopaque",
                 };
 
                 if (Arrays.asList(darkContentStyles).contains(style.toLowerCase())) {
@@ -276,7 +251,7 @@ public class StatusBar extends CordovaPlugin {
                     return;
                 }
 
-                LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
+                LOG.e(TAG, "Invalid style, must be either 'default' or 'lightcontent'");
             }
         }
     }

--- a/src/browser/StatusBarProxy.js
+++ b/src/browser/StatusBarProxy.js
@@ -33,10 +33,8 @@ function notSupported (win, fail) {
 
 module.exports = {
     isVisible: false,
-    styleBlackTranslucent: notSupported,
     styleDefault: notSupported,
     styleLightContent: notSupported,
-    styleBlackOpaque: notSupported,
     overlaysWebView: notSupported,
     styleLightContect: notSupported,
     backgroundColorByName: notSupported,

--- a/src/ios/CDVStatusBar.h
+++ b/src/ios/CDVStatusBar.h
@@ -36,8 +36,6 @@
 
 - (void) styleDefault:(CDVInvokedUrlCommand*)command;
 - (void) styleLightContent:(CDVInvokedUrlCommand*)command;
-- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command;
-- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command;
 
 - (void) backgroundColorByName:(CDVInvokedUrlCommand*)command;
 - (void) backgroundColorByHexString:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -138,9 +138,6 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     setting  = @"StatusBarStyle";
     if ([self settingForKey:setting]) {
         NSString * styleSetting = [self settingForKey:setting];
-        if ([styleSetting isEqualToString:@"blacktranslucent"] || [styleSetting isEqualToString:@"blackopaque"]) {
-            NSLog(@"%@ is deprecated and will be removed in next major release, use lightcontent", styleSetting);
-        }
         [self setStatusBarStyle:styleSetting];
     }
 

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -282,17 +282,13 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
 - (void) setStatusBarStyle:(NSString*)statusBarStyle
 {
-    // default, lightContent, blackTranslucent, blackOpaque
+    // default, lightContent
     NSString* lcStatusBarStyle = [statusBarStyle lowercaseString];
 
     if ([lcStatusBarStyle isEqualToString:@"default"]) {
         [self styleDefault:nil];
     } else if ([lcStatusBarStyle isEqualToString:@"lightcontent"]) {
         [self styleLightContent:nil];
-    } else if ([lcStatusBarStyle isEqualToString:@"blacktranslucent"]) {
-        [self styleBlackTranslucent:nil];
-    } else if ([lcStatusBarStyle isEqualToString:@"blackopaque"]) {
-        [self styleBlackOpaque:nil];
     }
 }
 
@@ -307,16 +303,6 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 }
 
 - (void) styleLightContent:(CDVInvokedUrlCommand*)command
-{
-    [self setStyleForStatusBar:UIStatusBarStyleLightContent];
-}
-
-- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command
-{
-    [self setStyleForStatusBar:UIStatusBarStyleLightContent];
-}
-
-- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command
 {
     [self setStyleForStatusBar:UIStatusBarStyleLightContent];
 }

--- a/src/windows/StatusBarProxy.js
+++ b/src/windows/StatusBarProxy.js
@@ -80,16 +80,6 @@ module.exports = {
         }
     },
 
-    styleBlackTranslucent: function () {
-        // #88000000 ? Apple says to use lightContent instead
-        return module.exports.styleLightContent();
-    },
-
-    styleBlackOpaque: function () {
-        // #FF000000 ? Apple says to use lightContent instead
-        return module.exports.styleLightContent();
-    },
-
     backgroundColorByHexString: function (win, fail, args) {
         var rgb = hexToRgb(args[0]);
         if (isSupported()) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -44,7 +44,6 @@ exports.defineAutoTests = function () {
         });
 
         it('statusbar.spec.4 should have set style methods', function () {
-
             expect(window.StatusBar.styleDefault).toBeDefined();
             expect(typeof window.StatusBar.styleDefault).toBe('function');
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -44,17 +44,12 @@ exports.defineAutoTests = function () {
         });
 
         it('statusbar.spec.4 should have set style methods', function () {
-            expect(window.StatusBar.styleBlackTranslucent).toBeDefined();
-            expect(typeof window.StatusBar.styleBlackTranslucent).toBe('function');
 
             expect(window.StatusBar.styleDefault).toBeDefined();
             expect(typeof window.StatusBar.styleDefault).toBe('function');
 
             expect(window.StatusBar.styleLightContent).toBeDefined();
             expect(typeof window.StatusBar.styleLightContent).toBe('function');
-
-            expect(window.StatusBar.styleBlackOpaque).toBeDefined();
-            expect(typeof window.StatusBar.styleBlackOpaque).toBe('function');
 
             expect(window.StatusBar.overlaysWebView).toBeDefined();
             expect(typeof window.StatusBar.overlaysWebView).toBe('function');
@@ -83,11 +78,6 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     function doColor1 () {
         log('set color=red');
         StatusBar.backgroundColorByName('red');
-    }
-
-    function doColor2 () {
-        log('set style=translucent black');
-        StatusBar.styleBlackTranslucent();
     }
 
     function doColor3 () {
@@ -151,14 +141,6 @@ exports.defineManualTests = function (contentEl, createActionButton) {
             doColor1();
         },
         'action-color1'
-    );
-
-    createActionButton(
-        'Style=translucent black',
-        function () {
-            doColor2();
-        },
-        'action-color2'
     );
 
     createActionButton(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,16 +35,6 @@ interface StatusBar {
     styleLightContent(): void;
 
     /**
-    * Use the blackTranslucent statusbar (light text, for dark backgrounds).
-    */
-    styleBlackTranslucent(): void;
-
-    /**
-    * Use the blackOpaque statusbar (light text, for dark backgrounds).
-    */
-    styleBlackOpaque(): void;
-
-    /**
     * On iOS 7, when you set StatusBar.statusBarOverlaysWebView to false,
     * you can set the background color of the statusbar by color name.
     *

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -57,16 +57,6 @@ var StatusBar = {
         exec(null, null, 'StatusBar', 'styleLightContent', []);
     },
 
-    styleBlackTranslucent: function () {
-        console.warn('styleBlackTranslucent is deprecated and will be removed in next major release, use styleLightContent');
-        exec(null, null, 'StatusBar', 'styleBlackTranslucent', []);
-    },
-
-    styleBlackOpaque: function () {
-        console.warn('styleBlackOpaque is deprecated and will be removed in next major release, use styleLightContent');
-        exec(null, null, 'StatusBar', 'styleBlackOpaque', []);
-    },
-
     backgroundColorByName: function (colorname) {
         return StatusBar.backgroundColorByHexString(namedColors[colorname]);
     },


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
all


### Motivation and Context
`blacktranslucent` and `blackopaque` styles and the corresponding methods StatusBar.styleBlackTranslucent and StatusBar.styleBlackOpaque are deprecated. 
Remove them.


### Description
Removes the previous deprecated methods that do the same as lightcontent.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
