### PR TITLE
Android: fix 'darkContentStyles' with new 'WindowInsetsControllerCompat'

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -254,6 +254,7 @@ public class StatusBar extends CordovaPlugin {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (style != null && !style.isEmpty()) {
                 View decorView = cordova.getActivity().getWindow().getDecorView();
+                WindowInsetsControllerCompat wic = ViewCompat.getWindowInsetsController(decorView);
                 int uiOptions = decorView.getSystemUiVisibility();
 
                 String[] darkContentStyles = {
@@ -268,11 +269,13 @@ public class StatusBar extends CordovaPlugin {
 
                 if (Arrays.asList(darkContentStyles).contains(style.toLowerCase())) {
                     decorView.setSystemUiVisibility(uiOptions | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    if (wic != null) wic.setAppearanceLightStatusBars(true);
                     return;
                 }
 
                 if (Arrays.asList(lightContentStyles).contains(style.toLowerCase())) {
                     decorView.setSystemUiVisibility(uiOptions & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    if (wic != null) wic.setAppearanceLightStatusBars(false);
                     return;
                 }
 

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -26,6 +26,9 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaInterface;


### PR DESCRIPTION
Added 'WindowInsetsControllerCompat.setAppearanceLightStatusBars' to 'setStatusBarStyle' to fix dark content styles

### Platforms affected

- Android

### Motivation and Context

In Android 12 the dark-content style wasn't working anymore due to the deprecated `View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR`.

### Description

I've added the new `WindowInsetsControllerCompat.setAppearanceLightStatusBars` method to make it work again.

### Testing

Built the app with Cordova 11.0.0 and Android Studio  and tested on Android 12 emulator, Android 11 device and Android 7 device.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
