### PR TITLE
fix(android)!: styleDefault not working on new devices

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -26,6 +26,9 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaInterface;
@@ -253,8 +256,9 @@ public class StatusBar extends CordovaPlugin {
     private void setStatusBarStyle(final String style) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             if (style != null && !style.isEmpty()) {
-                View decorView = cordova.getActivity().getWindow().getDecorView();
-                int uiOptions = decorView.getSystemUiVisibility();
+                Window window = cordova.getActivity().getWindow();
+                View decorView = window.getDecorView();
+                WindowInsetsControllerCompat windowInsetsControllerCompat = WindowCompat.getInsetsController(window, decorView);
 
                 String[] darkContentStyles = {
                     "default",
@@ -267,12 +271,12 @@ public class StatusBar extends CordovaPlugin {
                 };
 
                 if (Arrays.asList(darkContentStyles).contains(style.toLowerCase())) {
-                    decorView.setSystemUiVisibility(uiOptions | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    windowInsetsControllerCompat.setAppearanceLightStatusBars(true);
                     return;
                 }
 
                 if (Arrays.asList(lightContentStyles).contains(style.toLowerCase())) {
-                    decorView.setSystemUiVisibility(uiOptions & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    windowInsetsControllerCompat.setAppearanceLightStatusBars(false);
                     return;
                 }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android


### Motivation and Context
styleDefault is not working on some Android 12/13 devices, this PR makes it work again.

### Description
The PR uses `WindowInsetsControllerCompat.setAppearanceLightStatusBars` instead of the deprecated `SYSTEM_UI_FLAG_LIGHT_STATUS_BAR`. Makes `styleDefault` work on new devices.

It's a breaking change because it requires `androidx.core`, which is only available on cordova-android >= 9. At the moment the plugin doesn't have any cordova-android version requirement, so requiring cordova-android >= 9 is breaking.

A separate PR would be sent to set the engines if this PR gets accepted.

closes https://github.com/apache/cordova-plugin-statusbar/issues/236

closes https://github.com/apache/cordova-plugin-statusbar/pull/235, which is a similar PR but uses deprecated methods.

### Testing
Tested on real devices and emulators


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
