### PR TITLE
refactor(android): Remove unused code

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -54,24 +54,21 @@ public class StatusBar extends CordovaPlugin {
         LOG.v(TAG, "StatusBar: initialization");
         super.initialize(cordova, webView);
 
-        this.cordova.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                // Clear flag FLAG_FORCE_NOT_FULLSCREEN which is set initially
-                // by the Cordova.
-                Window window = cordova.getActivity().getWindow();
-                window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+        this.cordova.getActivity().runOnUiThread(() -> {
+            // Clear flag FLAG_FORCE_NOT_FULLSCREEN which is set initially
+            // by the Cordova.
+            Window window = cordova.getActivity().getWindow();
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
 
-                // Read 'StatusBarOverlaysWebView' from config.xml, default is true.
-                setStatusBarTransparent(preferences.getBoolean("StatusBarOverlaysWebView", true));
+            // Read 'StatusBarOverlaysWebView' from config.xml, default is true.
+            setStatusBarTransparent(preferences.getBoolean("StatusBarOverlaysWebView", true));
 
-                // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
-                setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
+            // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
+            setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
 
-                // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
-                String styleSetting = preferences.getString("StatusBarStyle", "lightcontent");
-                setStatusBarStyle(styleSetting);
-            }
+            // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
+            String styleSetting = preferences.getString("StatusBarStyle", "lightcontent");
+            setStatusBarStyle(styleSetting);
         });
     }
 
@@ -84,7 +81,7 @@ public class StatusBar extends CordovaPlugin {
      * @return                  True if the action was valid, false otherwise.
      */
     @Override
-    public boolean execute(final String action, final CordovaArgs args, final CallbackContext callbackContext) throws JSONException {
+    public boolean execute(final String action, final CordovaArgs args, final CallbackContext callbackContext) {
         LOG.v(TAG, "Executing action: " + action);
         final Activity activity = this.cordova.getActivity();
         final Window window = activity.getWindow();
@@ -96,97 +93,64 @@ public class StatusBar extends CordovaPlugin {
         }
 
         if ("show".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    // SYSTEM_UI_FLAG_FULLSCREEN is available since JellyBean, but we
-                    // use KitKat here to be aligned with "Fullscreen"  preference
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        int uiOptions = window.getDecorView().getSystemUiVisibility();
-                        uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
-                        uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
+            this.cordova.getActivity().runOnUiThread(() -> {
+                int uiOptions = window.getDecorView().getSystemUiVisibility();
+                uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+                uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
 
-                        window.getDecorView().setSystemUiVisibility(uiOptions);
-                    }
+                window.getDecorView().setSystemUiVisibility(uiOptions);
 
-                    // CB-11197 We still need to update LayoutParams to force status bar
-                    // to be hidden when entering e.g. text fields
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
+                // CB-11197 We still need to update LayoutParams to force status bar
+                // to be hidden when entering e.g. text fields
+                window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             });
             return true;
         }
 
         if ("hide".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    // SYSTEM_UI_FLAG_FULLSCREEN is available since JellyBean, but we
-                    // use KitKat here to be aligned with "Fullscreen"  preference
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                        int uiOptions = window.getDecorView().getSystemUiVisibility()
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN;
+            this.cordova.getActivity().runOnUiThread(() -> {
+                int uiOptions = window.getDecorView().getSystemUiVisibility()
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN;
 
-                        window.getDecorView().setSystemUiVisibility(uiOptions);
-                    }
+                window.getDecorView().setSystemUiVisibility(uiOptions);
 
-                    // CB-11197 We still need to update LayoutParams to force status bar
-                    // to be hidden when entering e.g. text fields
-                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                }
+                // CB-11197 We still need to update LayoutParams to force status bar
+                // to be hidden when entering e.g. text fields
+                window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             });
             return true;
         }
 
         if ("backgroundColorByHexString".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        setStatusBarBackgroundColor(args.getString(0));
-                    } catch (JSONException ignore) {
-                        LOG.e(TAG, "Invalid hexString argument, use f.i. '#777777'");
-                    }
+            this.cordova.getActivity().runOnUiThread(() -> {
+                try {
+                    setStatusBarBackgroundColor(args.getString(0));
+                } catch (JSONException ignore) {
+                    LOG.e(TAG, "Invalid hexString argument, use f.i. '#777777'");
                 }
             });
             return true;
         }
 
         if ("overlaysWebView".equals(action)) {
-            if (Build.VERSION.SDK_INT >= 21) {
-                this.cordova.getActivity().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            setStatusBarTransparent(args.getBoolean(0));
-                        } catch (JSONException ignore) {
-                            LOG.e(TAG, "Invalid boolean argument");
-                        }
+                this.cordova.getActivity().runOnUiThread(() -> {
+                    try {
+                        setStatusBarTransparent(args.getBoolean(0));
+                    } catch (JSONException ignore) {
+                        LOG.e(TAG, "Invalid boolean argument");
                     }
                 });
                 return true;
-            }
-            else return args.getBoolean(0) == false;
         }
 
         if ("styleDefault".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("default");
-                }
-            });
+            this.cordova.getActivity().runOnUiThread(() -> setStatusBarStyle("default"));
             return true;
         }
 
         if ("styleLightContent".equals(action)) {
-            this.cordova.getActivity().runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    setStatusBarStyle("lightcontent");
-                }
-            });
+            this.cordova.getActivity().runOnUiThread(() -> setStatusBarStyle("lightcontent"));
             return true;
         }
 
@@ -194,39 +158,35 @@ public class StatusBar extends CordovaPlugin {
     }
 
     private void setStatusBarBackgroundColor(final String colorPref) {
-        if (Build.VERSION.SDK_INT >= 21) {
-            if (colorPref != null && !colorPref.isEmpty()) {
-                final Window window = cordova.getActivity().getWindow();
-                // Method and constants not available on all SDKs but we want to be able to compile this code with any SDK
-                window.clearFlags(0x04000000); // SDK 19: WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-                window.addFlags(0x80000000); // SDK 21: WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-                try {
-                    // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21
-                    window.getClass().getMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
-                } catch (IllegalArgumentException ignore) {
-                    LOG.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
-                } catch (Exception ignore) {
-                    // this should not happen, only in case Android removes this method in a version > 21
-                    LOG.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);
-                }
+        if (colorPref != null && !colorPref.isEmpty()) {
+            final Window window = cordova.getActivity().getWindow();
+            // Method and constants not available on all SDKs but we want to be able to compile this code with any SDK
+            window.clearFlags(0x04000000); // SDK 19: WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.addFlags(0x80000000); // SDK 21: WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            try {
+                // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21
+                window.getClass().getMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
+            } catch (IllegalArgumentException ignore) {
+                LOG.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
+            } catch (Exception ignore) {
+                // this should not happen, only in case Android removes this method in a version > 21
+                LOG.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);
             }
         }
     }
 
     private void setStatusBarTransparent(final boolean transparent) {
-        if (Build.VERSION.SDK_INT >= 21) {
-            final Window window = cordova.getActivity().getWindow();
-            if (transparent) {
-                window.getDecorView().setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-                window.setStatusBarColor(Color.TRANSPARENT);
-            }
-            else {
-                window.getDecorView().setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_VISIBLE);
-            }
+        final Window window = cordova.getActivity().getWindow();
+        if (transparent) {
+            window.getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+            window.setStatusBarColor(Color.TRANSPARENT);
+        }
+        else {
+            window.getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_VISIBLE);
         }
     }
 


### PR DESCRIPTION
Since the next major version of the plugin [will require](https://github.com/apache/cordova-plugin-statusbar/pull/241) cordova-android 10, all the kitkat or SDK 21 version checks can be removed since cordova-android 10 supports SDK 22+.

Also the plugin doesn't throws JSONException since the error is catch.

Also replace the Runnable with lambdas.