### PR TITLE
refactor(android)!: setStatusBarBackgroundColor

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -169,21 +169,20 @@ public class StatusBar extends CordovaPlugin {
     }
 
     private void setStatusBarBackgroundColor(final String colorPref) {
-        if (colorPref != null && !colorPref.isEmpty()) {
-            final Window window = cordova.getActivity().getWindow();
-            // Method and constants not available on all SDKs but we want to be able to compile this code with any SDK
-            window.clearFlags(0x04000000); // SDK 19: WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-            window.addFlags(0x80000000); // SDK 21: WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            try {
-                // Using reflection makes sure any 5.0+ device will work without having to compile with SDK level 21
-                window.getClass().getMethod("setStatusBarColor", int.class).invoke(window, Color.parseColor(colorPref));
-            } catch (IllegalArgumentException ignore) {
-                LOG.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
-            } catch (Exception ignore) {
-                // this should not happen, only in case Android removes this method in a version > 21
-                LOG.w(TAG, "Method window.setStatusBarColor not found for SDK level " + Build.VERSION.SDK_INT);
-            }
+        if (colorPref.isEmpty()) return;
+
+        int color;
+        try {
+            color = Color.parseColor(colorPref);
+        } catch (IllegalArgumentException ignore) {
+            LOG.e(TAG, "Invalid hexString argument, use f.i. '#999999'");
+            return;
         }
+
+        final Window window = cordova.getActivity().getWindow();
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS); // SDK 19-30
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS); // SDK 21
+        window.setStatusBarColor(color);
     }
 
     private void setStatusBarTransparent(final boolean transparent) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

refactor `setStatusBarBackgroundColor`

### Description
<!-- Describe your changes in detail -->

`setStatusBarBackgroundColor` use to use reflection so that the project didn't need to be compile with SDK level 21 or higher.

Per plugin's defined cordova-android requirement, in `plugin.xml` and `package.json`, the minimum supported SDK level is 22. Reflection should not be required anymore.

Also, we do not need to type in the hex values anymore on the following lines as SDK 22 is minimum and the `WindowManager.LayoutParams` is available.

```java
window.clearFlags(0x04000000); // SDK 19: WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
 window.addFlags(0x80000000); // SDK 21: WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
 ```

### Testing
<!-- Please describe in detail how you tested your changes. -->

Build with AS

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
