### PR TITLE
fix(iOS): Inline code to find the webview's scrollView

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -25,6 +25,7 @@
 
 #import "CDVStatusBar.h"
 #import <objc/runtime.h>
+#import <objc/message.h>
 #import <Cordova/CDVViewController.h>
 
 static const void *kHideStatusBar = &kHideStatusBar;
@@ -143,9 +144,9 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
     setting  = @"StatusBarDefaultScrollToTop";
     if ([self settingForKey:setting]) {
-        self.webView.scrollView.scrollsToTop = [(NSNumber*)[self settingForKey:setting] boolValue];
+        [self webViewScrollView].scrollsToTop = [(NSNumber*)[self settingForKey:setting] boolValue];
     } else {
-        self.webView.scrollView.scrollsToTop = NO;
+        [self webViewScrollView].scrollsToTop = NO;
     }
  
     // blank scroll view to intercept status bar taps
@@ -460,6 +461,17 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 {
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:@"statusBarHidden"];
     [[NSNotificationCenter defaultCenter]removeObserver:self name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
+}
+
+- (UIScrollView *)webViewScrollView
+{
+    SEL scrollViewSelector = NSSelectorFromString(@"scrollView");
+
+    if ([self.webView respondsToSelector:scrollViewSelector]) {
+        return ((id (*)(id, SEL))objc_msgSend)(self.webView, scrollViewSelector);
+    }
+
+    return nil;
 }
 
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Ref: https://github.com/apache/cordova-ios/pull/1400


### Description
<!-- Describe your changes in detail -->
Currently this works because of a category extension that adds a `scrollView` method to every UIView instance, but that causes issues for SwiftUI so we want to remove that extension from cordova-ios.

Since we do need to be able to look up the scrollView in this plugin, we can just define a private local method that does the same thing in a way that doesn't pollute global UIKit classes.
