### PR TITLE
(android) Don't overwrite the whole SystemUiVisibility in setStatusBarTransparent

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -185,9 +185,10 @@ public class StatusBar extends CordovaPlugin {
 
     private void setStatusBarTransparent(final boolean isTransparent) {
         final Window window = cordova.getActivity().getWindow();
+        int uiOptions = window.getDecorView().getSystemUiVisibility();
         int visibility = isTransparent
-            ? View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-            : View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
+            ? uiOptions | View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            : uiOptions | View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
 
         window.getDecorView().setSystemUiVisibility(visibility);
 


### PR DESCRIPTION
Fixes #275


### Platforms affected

Android

### Motivation and Context
in `setStatusBarTransparent` function, current SystemUiVisibility is being replaced by the new one, which is incorrect as stated in #275.



### Description
Like other places in the same codebase, I just called `getSystemUiVisibility` before applying the new flags and used current visibility as a base option for those flags.



### Testing

It's already mentioned in #275.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
