### PR TITLE
(iOS) Handle frame origin when status bar isn't overlaying the web view

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -210,6 +210,8 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         statusBarFrame.origin.y = 0;
     }
 
+    statusBarFrame.size.height = self.webView.frame.origin.y; //frameYStart
+
     _statusBarBackgroundView = [[UIView alloc] initWithFrame:statusBarFrame];
     _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
     _statusBarBackgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth  | UIViewAutoresizingFlexibleBottomMargin);
@@ -440,11 +442,11 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
     CGRect frame = self.webView.frame;
     CGFloat height = statusBarFrame.size.height;
+    float safeAreaTop = self.webView.safeAreaInsets.top;
 
     if (!self.statusBarOverlaysWebView) {
-        frame.origin.y = height;
+        frame.origin.y = height >= safeAreaTop ? height : safeAreaTop;
     } else {
-        float safeAreaTop = self.webView.safeAreaInsets.top;
         if (height >= safeAreaTop && safeAreaTop >0) {
             // Sometimes when in-call/recording/hotspot larger status bar is present, the safeAreaTop is 40 but we want frame.origin.y to be 20
             frame.origin.y = safeAreaTop == 40 ? 20 : height - safeAreaTop;

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -105,8 +105,8 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     //add a small delay ( 0.1 seconds ) or statusbar size will be wrong
     __weak CDVStatusBar* weakSelf = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [weakSelf resizeStatusBarBackgroundView];
         [weakSelf resizeWebView];
+        [weakSelf resizeStatusBarBackgroundView];
     });
 }
 
@@ -423,6 +423,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 
 -(void)resizeStatusBarBackgroundView {
     CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+    statusBarFrame.size.height = self.webView.frame.origin.y; // Set the height to the current webView origin in case it has been changed after resizing
     CGRect sbBgFrame = _statusBarBackgroundView.frame;
     sbBgFrame.size = statusBarFrame.size;
     _statusBarBackgroundView.frame = sbBgFrame;
@@ -445,7 +446,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     float safeAreaTop = self.webView.safeAreaInsets.top;
 
     if (!self.statusBarOverlaysWebView) {
-        frame.origin.y = height >= safeAreaTop ? height : safeAreaTop;
+        frame.origin.y = height >= safeAreaTop || height == 0 ? height : safeAreaTop;
     } else {
         if (height >= safeAreaTop && safeAreaTop >0) {
             // Sometimes when in-call/recording/hotspot larger status bar is present, the safeAreaTop is 40 but we want frame.origin.y to be 20


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
Fixes #243



### Description
Frame y origin would be incorrect on iOS phones with floating islands when the statusbar isn't overlaying the web view. This change changes the origin so that it takes the webview's safeAreaTop into account



### Testing
Tested on iOS 17 and iOS 18 on iPhone 14 and simulators



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
