### PR TITLE
feat: add support of get status, navigation bars and total screen height of the device

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -248,13 +248,33 @@ public class StatusBar extends CordovaPlugin {
      * Set the status bar transparency
      */
     private void setStatusBarTransparent(final boolean isTransparent) {
-        int visibility = isTransparent
-            ? View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-            : View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
+        if (!isTransparent) {
+            window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE);
+            return;
+        }
 
-        window.getDecorView().setSystemUiVisibility(visibility);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowCompat.setDecorFitsSystemWindows(window, false);
+            window.setStatusBarColor(Color.TRANSPARENT);
+        }
+        else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+            View decorView = window.getDecorView();
 
-        if (isTransparent) {
+            int flags = decorView.getSystemUiVisibility();
+            flags |= View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
+            flags |= View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+            flags |= View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
+            decorView.setSystemUiVisibility(flags);
+
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            window.setStatusBarColor(Color.TRANSPARENT);
+
+            window.setNavigationBarColor(Color.TRANSPARENT);
+        }
+        else {
+            int visibility = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+            window.getDecorView().setSystemUiVisibility(visibility);
             window.setStatusBarColor(Color.TRANSPARENT);
         }
     }
@@ -347,7 +367,7 @@ public class StatusBar extends CordovaPlugin {
             if (insets != null) {
                 return insets.getInsetsIgnoringVisibility(WindowInsets.Type.navigationBars()).bottom;
             }
-        } else {
+        } else if (isEdgeToEdge()) {
             Resources resources = activity.getResources();
             int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
             if (resourceId > 0 && hasNavigationBar()) {

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -19,11 +19,16 @@
  */
 package org.apache.cordova.statusbar;
 
+import android.app.Activity;
 import android.graphics.Color;
+import android.graphics.Rect;
 import android.os.Build;
+import android.util.DisplayMetrics;
 import android.view.View;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
+import android.view.WindowMetrics;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.WindowCompat;
@@ -41,6 +46,7 @@ import org.json.JSONException;
 public class StatusBar extends CordovaPlugin {
     private static final String TAG = "StatusBar";
 
+    // Action constants
     private static final String ACTION_HIDE = "hide";
     private static final String ACTION_SHOW = "show";
     private static final String ACTION_READY = "_ready";
@@ -48,7 +54,11 @@ public class StatusBar extends CordovaPlugin {
     private static final String ACTION_OVERLAYS_WEB_VIEW = "overlaysWebView";
     private static final String ACTION_STYLE_DEFAULT = "styleDefault";
     private static final String ACTION_STYLE_LIGHT_CONTENT = "styleLightContent";
+    private static final String ACTION_GET_NAVIGATION_BAR_HEIGHT = "getNavigationBarHeight";
+    private static final String ACTION_GET_STATUS_BAR_HEIGHT = "getStatusBarHeight";
+    private static final String ACTION_GET_TOTAL_SCREEN_HEIGHT = "getTotalScreenHeight";
 
+    // Style constants
     private static final String STYLE_DEFAULT = "default";
     private static final String STYLE_LIGHT_CONTENT = "lightcontent";
 
@@ -107,31 +117,11 @@ public class StatusBar extends CordovaPlugin {
                 return true;
 
             case ACTION_SHOW:
-                activity.runOnUiThread(() -> {
-                    int uiOptions = window.getDecorView().getSystemUiVisibility();
-                    uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
-                    uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
-
-                    window.getDecorView().setSystemUiVisibility(uiOptions);
-
-                    // CB-11197 We still need to update LayoutParams to force status bar
-                    // to be hidden when entering e.g. text fields
-                    window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                });
+                activity.runOnUiThread(() -> showStatusBar());
                 return true;
 
             case ACTION_HIDE:
-                activity.runOnUiThread(() -> {
-                    int uiOptions = window.getDecorView().getSystemUiVisibility()
-                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_FULLSCREEN;
-
-                    window.getDecorView().setSystemUiVisibility(uiOptions);
-
-                    // CB-11197 We still need to update LayoutParams to force status bar
-                    // to be hidden when entering e.g. text fields
-                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                });
+                activity.runOnUiThread(() -> hideStatusBar());
                 return true;
 
             case ACTION_BACKGROUND_COLOR_BY_HEX_STRING:
@@ -162,11 +152,80 @@ public class StatusBar extends CordovaPlugin {
                 activity.runOnUiThread(() -> setStatusBarStyle(STYLE_LIGHT_CONTENT));
                 return true;
 
+            case ACTION_GET_NAVIGATION_BAR_HEIGHT:
+            case ACTION_GET_STATUS_BAR_HEIGHT:
+            case ACTION_GET_TOTAL_SCREEN_HEIGHT:
+                handleHeightRequests(action, callbackContext);
+                return true;
+
             default:
                 return false;
         }
     }
 
+    /**
+     * Handle all height-related requests
+     */
+    private void handleHeightRequests(String action, CallbackContext callbackContext) {
+        activity.runOnUiThread(() -> {
+            int height;
+            String logMessage;
+
+            switch (action) {
+                case ACTION_GET_NAVIGATION_BAR_HEIGHT:
+                    height = getNavigationBarHeight();
+                    logMessage = "Navigation bar height";
+                    break;
+                case ACTION_GET_STATUS_BAR_HEIGHT:
+                    height = getStatusBarHeight();
+                    logMessage = "Status bar height";
+                    break;
+                case ACTION_GET_TOTAL_SCREEN_HEIGHT:
+                    height = getTotalScreenHeight();
+                    logMessage = "Total screen height";
+                    break;
+                default:
+                    return;
+            }
+
+            LOG.d(TAG, logMessage + ": " + height);
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, height));
+        });
+    }
+
+    /**
+     * Show the status bar
+     */
+    private void showStatusBar() {
+        int uiOptions = window.getDecorView().getSystemUiVisibility();
+        uiOptions &= ~View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
+        uiOptions &= ~View.SYSTEM_UI_FLAG_FULLSCREEN;
+
+        window.getDecorView().setSystemUiVisibility(uiOptions);
+
+        // CB-11197 We still need to update LayoutParams to force status bar
+        // to be hidden when entering e.g. text fields
+        window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+    }
+
+    /**
+     * Hide the status bar
+     */
+    private void hideStatusBar() {
+        int uiOptions = window.getDecorView().getSystemUiVisibility()
+            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            | View.SYSTEM_UI_FLAG_FULLSCREEN;
+
+        window.getDecorView().setSystemUiVisibility(uiOptions);
+
+        // CB-11197 We still need to update LayoutParams to force status bar
+        // to be hidden when entering e.g. text fields
+        window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+    }
+
+    /**
+     * Set the status bar background color
+     */
     private void setStatusBarBackgroundColor(final String colorPref) {
         if (colorPref.isEmpty()) return;
 
@@ -183,8 +242,10 @@ public class StatusBar extends CordovaPlugin {
         window.setStatusBarColor(color);
     }
 
+    /**
+     * Set the status bar transparency
+     */
     private void setStatusBarTransparent(final boolean isTransparent) {
-        final Window window = cordova.getActivity().getWindow();
         int visibility = isTransparent
             ? View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
             : View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
@@ -196,6 +257,9 @@ public class StatusBar extends CordovaPlugin {
         }
     }
 
+    /**
+     * Set the status bar style
+     */
     private void setStatusBarStyle(final String style) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !style.isEmpty()) {
             View decorView = window.getDecorView();
@@ -208,6 +272,58 @@ public class StatusBar extends CordovaPlugin {
             } else {
                 LOG.e(TAG, "Invalid style, must be either 'default' or 'lightcontent'");
             }
+        }
+    }
+
+    /**
+     * Gets window insets for API 30+ devices
+     */
+    private WindowInsets getWindowInsets() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            View decorView = window.getDecorView();
+            return decorView.getRootWindowInsets();
+        }
+        return null;
+    }
+
+    /**
+     * Gets the bottom navigation bar height
+     */
+    private int getNavigationBarHeight() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsets insets = getWindowInsets();
+            if (insets != null) {
+                return insets.getInsetsIgnoringVisibility(WindowInsets.Type.navigationBars()).bottom;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Gets the top status bar height
+     */
+    private int getStatusBarHeight() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsets insets = getWindowInsets();
+            if (insets != null) {
+                return insets.getInsetsIgnoringVisibility(WindowInsets.Type.statusBars()).top;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Gets the total screen height
+     */
+    private int getTotalScreenHeight() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowManager windowManager = activity.getSystemService(WindowManager.class);
+            WindowMetrics metrics = windowManager.getCurrentWindowMetrics();
+            return metrics.getBounds().height();
+        } else {
+            DisplayMetrics displayMetrics = new DisplayMetrics();
+            activity.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+            return displayMetrics.heightPixels;
         }
     }
 }

--- a/src/browser/StatusBarProxy.js
+++ b/src/browser/StatusBarProxy.js
@@ -40,7 +40,10 @@ module.exports = {
     backgroundColorByHexString: notSupported,
     hide: notSupported,
     show: notSupported,
-    _ready: notSupported
+    _ready: notSupported,
+    getNavigationBarHeight: notSupported,
+    getStatusBarHeight: notSupported,
+    getTotalScreenHeight: notSupported
 };
 
 require('cordova/exec/proxy').add('StatusBar', module.exports);

--- a/src/ios/CDVStatusBar.h
+++ b/src/ios/CDVStatusBar.h
@@ -6,9 +6,9 @@
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -42,7 +42,11 @@
 
 - (void) hide:(CDVInvokedUrlCommand*)command;
 - (void) show:(CDVInvokedUrlCommand*)command;
-    
+
 - (void) _ready:(CDVInvokedUrlCommand*)command;
+
+- (void) getStatusBarHeight:(CDVInvokedUrlCommand*)command;
+- (void) getNavigationBarHeight:(CDVInvokedUrlCommand*)command;
+- (void) getTotalScreenHeight:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -148,7 +148,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     } else {
         [self webViewScrollView].scrollsToTop = NO;
     }
- 
+
     // blank scroll view to intercept status bar taps
     UIScrollView *fakeScrollView = [[UIScrollView alloc] initWithFrame:UIScreen.mainScreen.bounds];
     fakeScrollView.delegate = self;
@@ -454,7 +454,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     }
     frame.size.height -= frame.origin.y;
     self.webView.frame = frame;
-    
+
 }
 
 - (void) dealloc
@@ -481,6 +481,64 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
 {
     [self fireTappedEvent];
     return NO;
+}
+
+#pragma mark - Height Measurement Methods
+
+- (void) getStatusBarHeight:(CDVInvokedUrlCommand*)command
+{
+    CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+
+    if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        CGFloat topPadding = window.safeAreaInsets.top;
+
+        if (topPadding > 20) {
+            statusBarHeight = topPadding;
+        }
+    }
+
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:statusBarHeight];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+- (void) getNavigationBarHeight:(CDVInvokedUrlCommand*)command
+{
+    CGFloat navigationBarHeight = 0;
+
+    if ([self.viewController isKindOfClass:[UINavigationController class]]) {
+        UINavigationController *navController = (UINavigationController *)self.viewController;
+        navigationBarHeight = navController.navigationBar.frame.size.height;
+    } else if (self.viewController.navigationController) {
+        navigationBarHeight = self.viewController.navigationController.navigationBar.frame.size.height;
+    } else {
+        navigationBarHeight = 44.0; // Standard navigation bar height
+
+        if (@available(iOS 11.0, *)) {
+            UIWindow *window = UIApplication.sharedApplication.keyWindow;
+            if (window.safeAreaInsets.top > 20) {
+                navigationBarHeight = 44.0; // Still 44 for navigation bar itself, excluding status bar
+            }
+        }
+    }
+
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:navigationBarHeight];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+}
+
+- (void) getTotalScreenHeight:(CDVInvokedUrlCommand*)command
+{
+    CGFloat screenHeight = 0;
+
+    CGRect screenBounds = [[UIScreen mainScreen] bounds];
+    screenHeight = screenBounds.size.height;
+
+    if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+    }
+
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:screenHeight];
+    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }
 
 @end

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -512,14 +512,7 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     } else if (self.viewController.navigationController) {
         navigationBarHeight = self.viewController.navigationController.navigationBar.frame.size.height;
     } else {
-        navigationBarHeight = 44.0; // Standard navigation bar height
-
-        if (@available(iOS 11.0, *)) {
-            UIWindow *window = UIApplication.sharedApplication.keyWindow;
-            if (window.safeAreaInsets.top > 20) {
-                navigationBarHeight = 44.0; // Still 44 for navigation bar itself, excluding status bar
-            }
-        }
+        navigationBarHeight = 0.0; // Standard navigation bar height
     }
 
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDouble:navigationBarHeight];

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -48,15 +48,15 @@ var namedColors = {
  * @param {Function} errorCallback - Optional error callback
  * @returns {*} - Return value from success callback if provided
  */
-function execStatusBarCommand(action, args, successCallback, errorCallback) {
+function execStatusBarCommand (action, args, successCallback, errorCallback) {
     return exec(
-        function(result) {
+        function (result) {
             if (typeof successCallback === 'function') {
                 return successCallback(result);
             }
             return result;
         },
-        function(error) {
+        function (error) {
             if (typeof errorCallback === 'function') {
                 errorCallback(error);
             }
@@ -72,32 +72,32 @@ function execStatusBarCommand(action, args, successCallback, errorCallback) {
  * @param {string} action - The action to execute
  * @param {Array} args - Arguments for the action
  */
-function execSimpleCommand(action, args) {
+function execSimpleCommand (action, args) {
     exec(null, null, 'StatusBar', action, args || []);
 }
 
 var StatusBar = {
     isVisible: true,
 
-    overlaysWebView: function(doOverlay) {
+    overlaysWebView: function (doOverlay) {
         execSimpleCommand('overlaysWebView', [doOverlay]);
     },
 
-    styleDefault: function() {
+    styleDefault: function () {
         // dark text (to be used on a light background)
         execSimpleCommand('styleDefault');
     },
 
-    styleLightContent: function() {
+    styleLightContent: function () {
         // light text (to be used on a dark background)
         execSimpleCommand('styleLightContent');
     },
 
-    backgroundColorByName: function(colorname) {
+    backgroundColorByName: function (colorname) {
         return StatusBar.backgroundColorByHexString(namedColors[colorname]);
     },
 
-    backgroundColorByHexString: function(hexString) {
+    backgroundColorByHexString: function (hexString) {
         if (hexString.charAt(0) !== '#') {
             hexString = '#' + hexString;
         }
@@ -110,12 +110,12 @@ var StatusBar = {
         execSimpleCommand('backgroundColorByHexString', [hexString]);
     },
 
-    hide: function() {
+    hide: function () {
         execSimpleCommand('hide');
         StatusBar.isVisible = false;
     },
 
-    show: function() {
+    show: function () {
         execSimpleCommand('show');
         StatusBar.isVisible = true;
     },
@@ -127,27 +127,27 @@ var StatusBar = {
      * @param {Function} errorCallback - Error callback
      * @returns {*} - Return value from success callback
      */
-    getHeight: function(elementType, successCallback, errorCallback) {
+    getHeight: function (elementType, successCallback, errorCallback) {
         return execStatusBarCommand(elementType, [], successCallback, errorCallback);
     },
 
-    getNavigationBarHeight: function(successCallback, errorCallback) {
+    getNavigationBarHeight: function (successCallback, errorCallback) {
         return StatusBar.getHeight('getNavigationBarHeight', successCallback, errorCallback);
     },
 
-    getStatusBarHeight: function(successCallback, errorCallback) {
+    getStatusBarHeight: function (successCallback, errorCallback) {
         return StatusBar.getHeight('getStatusBarHeight', successCallback, errorCallback);
     },
 
-    getTotalScreenHeight: function(successCallback, errorCallback) {
+    getTotalScreenHeight: function (successCallback, errorCallback) {
         return StatusBar.getHeight('getTotalScreenHeight', successCallback, errorCallback);
     }
 };
 
 // prime it. setTimeout so that proxy gets time to init
-window.setTimeout(function() {
+window.setTimeout(function () {
     exec(
-        function(res) {
+        function (res) {
             if (typeof res === 'object') {
                 if (res.type === 'tap') {
                     cordova.fireWindowEvent('statusTap');

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -40,28 +40,64 @@ var namedColors = {
     brown: '#A52A2A'
 };
 
+/**
+ * Helper function to execute cordova commands
+ * @param {string} action - The action to execute
+ * @param {Array} args - Arguments for the action
+ * @param {Function} successCallback - Optional success callback
+ * @param {Function} errorCallback - Optional error callback
+ * @returns {*} - Return value from success callback if provided
+ */
+function execStatusBarCommand(action, args, successCallback, errorCallback) {
+    return exec(
+        function(result) {
+            if (typeof successCallback === 'function') {
+                return successCallback(result);
+            }
+            return result;
+        },
+        function(error) {
+            if (typeof errorCallback === 'function') {
+                errorCallback(error);
+            }
+        },
+        'StatusBar',
+        action,
+        args || []
+    );
+}
+
+/**
+ * Simple command execution without callbacks
+ * @param {string} action - The action to execute
+ * @param {Array} args - Arguments for the action
+ */
+function execSimpleCommand(action, args) {
+    exec(null, null, 'StatusBar', action, args || []);
+}
+
 var StatusBar = {
     isVisible: true,
 
-    overlaysWebView: function (doOverlay) {
-        exec(null, null, 'StatusBar', 'overlaysWebView', [doOverlay]);
+    overlaysWebView: function(doOverlay) {
+        execSimpleCommand('overlaysWebView', [doOverlay]);
     },
 
-    styleDefault: function () {
-        // dark text ( to be used on a light background )
-        exec(null, null, 'StatusBar', 'styleDefault', []);
+    styleDefault: function() {
+        // dark text (to be used on a light background)
+        execSimpleCommand('styleDefault');
     },
 
-    styleLightContent: function () {
-        // light text ( to be used on a dark background )
-        exec(null, null, 'StatusBar', 'styleLightContent', []);
+    styleLightContent: function() {
+        // light text (to be used on a dark background)
+        execSimpleCommand('styleLightContent');
     },
 
-    backgroundColorByName: function (colorname) {
+    backgroundColorByName: function(colorname) {
         return StatusBar.backgroundColorByHexString(namedColors[colorname]);
     },
 
-    backgroundColorByHexString: function (hexString) {
+    backgroundColorByHexString: function(hexString) {
         if (hexString.charAt(0) !== '#') {
             hexString = '#' + hexString;
         }
@@ -71,24 +107,47 @@ var StatusBar = {
             hexString = '#' + split[1] + split[1] + split[2] + split[2] + split[3] + split[3];
         }
 
-        exec(null, null, 'StatusBar', 'backgroundColorByHexString', [hexString]);
+        execSimpleCommand('backgroundColorByHexString', [hexString]);
     },
 
-    hide: function () {
-        exec(null, null, 'StatusBar', 'hide', []);
+    hide: function() {
+        execSimpleCommand('hide');
         StatusBar.isVisible = false;
     },
 
-    show: function () {
-        exec(null, null, 'StatusBar', 'show', []);
+    show: function() {
+        execSimpleCommand('show');
         StatusBar.isVisible = true;
+    },
+
+    /**
+     * Gets the height of various UI elements
+     * @param {string} elementType - The element type to get height for
+     * @param {Function} successCallback - Success callback
+     * @param {Function} errorCallback - Error callback
+     * @returns {*} - Return value from success callback
+     */
+    getHeight: function(elementType, successCallback, errorCallback) {
+        return execStatusBarCommand(elementType, [], successCallback, errorCallback);
+    },
+
+    getNavigationBarHeight: function(successCallback, errorCallback) {
+        return StatusBar.getHeight('getNavigationBarHeight', successCallback, errorCallback);
+    },
+
+    getStatusBarHeight: function(successCallback, errorCallback) {
+        return StatusBar.getHeight('getStatusBarHeight', successCallback, errorCallback);
+    },
+
+    getTotalScreenHeight: function(successCallback, errorCallback) {
+        return StatusBar.getHeight('getTotalScreenHeight', successCallback, errorCallback);
     }
 };
 
 // prime it. setTimeout so that proxy gets time to init
-window.setTimeout(function () {
+window.setTimeout(function() {
     exec(
-        function (res) {
+        function(res) {
             if (typeof res === 'object') {
                 if (res.type === 'tap') {
                     cordova.fireWindowEvent('statusTap');


### PR DESCRIPTION
### Platforms affected
Android, iOS


### Motivation and Context
Due to new approach of building apps on Android 15 (edge-to-edge) it is needed to adjust the application views to support status bar and navigation bar padding to do not cover buttons of the app by system buttons. Additionally the same function was added to iOS



### Description
Added three new functions that are handy when set padding for different pages in the app getNavigationBarHeight, getStatusBarHeight and getTotalScreenHeight.


### Testing
Tested the changes by running the plugin as a part of Meteor.js application.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
