### PR TITLE
doc(readme): `StatusBar.backgroundColorByHexString` only supports `#RRGGBB` on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ CSS shorthand properties are also supported.
     StatusBar.backgroundColorByHexString("#333"); // => #333333
     StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
 
-On iOS, when you set StatusBar.overlaysWebView to false, you can set the background color of the statusbar by a hex string (#RRGGBB).
+On iOS only the format `#RRGGBB` is supported. An alpha value is not supported.
 
-On Android, when StatusBar.overlaysWebView is true, and on WP7&8, you can also specify values as #AARRGGBB, where AA is an alpha value.
+On Android, when StatusBar.overlaysWebView is true you can also specify values as #AARRGGBB, where AA is an alpha value.
 
 Supported Platforms
 -------------------


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The documentation for iOS about `StatusBar.backgroundColorByHexString` assumed, that an alpha value could be possible, when `StatusBar.overlaysWebView` is `true`. Or the documentation wanted to assume, that the background color can only be set if `StatusBar.overlaysWebView` is `true`. To avoid confusion, the documentation just states, that iOS supports only the format `#RRGGBB`.

On the Android part the `WP7&8` part was removed since Window Phone is not supported by this plugin anymore.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
