### PR TITLE
doc(readme): background transparent on iOS when `StatusBarOverlaysWebView` is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,21 @@ Preferences
 
         <preference name="StatusBarOverlaysWebView" value="true" />
 
+    ##### iOS Specifics
+
+    The status bar will be transparent if `StatusBarOverlaysWebView` is set to `true`. A background color cannot be applied.
+
     ##### Android Quirks
     
     Only supported on Android 5 or later. Earlier versions will ignore this preference.
 
-- __StatusBarBackgroundColor__ (color hex string, no default value). Set the background color of the statusbar by a hex string (#RRGGBB) at startup. If this value is not set, the background color will be transparent. If `StatusBarOverlaysWebView` is set to true, then a 8 digit hex (#AARRGGBB) string can optionally be used to define the transparency.
+- __StatusBarBackgroundColor__ (color hex string, no default value). Set the background color of the statusbar by a hex string (#RRGGBB) at startup. If this value is not set, the background color will be transparent.
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
+
+    #### Android Specifics
+
+    If `StatusBarOverlaysWebView` is set to true, then a 8 digit hex (#AARRGGBB) string can optionally be used to define the transparency.
 
 - __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: `default`, `lightcontent`.
 
@@ -216,9 +224,9 @@ CSS shorthand properties are also supported.
     StatusBar.backgroundColorByHexString("#333"); // => #333333
     StatusBar.backgroundColorByHexString("#FAB"); // => #FFAABB
 
-On iOS, when you set StatusBar.overlaysWebView to false, you can set the background color of the statusbar by a hex string (#RRGGBB).
+On iOS you can set the background color of the statusbar by a hex string (#RRGGBB) if StatusBar.overlaysWebView is false.
 
-On Android, when StatusBar.overlaysWebView is true, and on WP7&8, you can also specify values as #AARRGGBB, where AA is an alpha value.
+On Android, when StatusBar.overlaysWebView is true you can also specify values as #AARRGGBB, where AA is an alpha value.
 
 Supported Platforms
 -------------------


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The documentation made not clear, that the status bar background color is transparent on iOS when `StatusBarOverlaysWebView` is set to `true` and cannot be changed by `StatusBarBackgroundColor`.

I looked in the code and the status bar background view is removed if `StatusBarOverlaysWebView` is `true`, which is the default:

https://github.com/apache/cordova-plugin-statusbar/blob/70f444534f5164ce0c8fae3508b3d8cc68f34beb/src/ios/CDVStatusBar.m#L230-L232

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
