### PR TITLE
doc(readme): move iOS `viewport-fit=cover` quirk directly to `StatusBarOverlaysWebView`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ Preferences
 
     ##### iOS Specifics
 
-    The status bar will be transparent if `StatusBarOverlaysWebView` is set to `true`. A background color cannot be applied.
+    The status bar will be transparent if `StatusBarOverlaysWebView` is set to `true`. A background color cannot be applied. Since iOS 11 you must also include `viewport-fit=cover` in your `<meta name="viewport" content="...">` tag if you want the status bar to overlay the webview:
+
+    ```html
+    <meta name="viewport" content="initial-scale=1, width=device-width, viewport-fit=cover">
+    ```
 
     ##### Android Quirks
     
@@ -97,15 +101,6 @@ if (cordova.platformId == 'android') {
     StatusBar.backgroundColorByHexString('#33000000');
 }
 ```
-
-### iOS Quirks
-Starting with iOS 11 you must include `viewport-fit=cover` in your viewport meta tag if you want the status bar to overlay the webview:
-
-```html
-<meta name="viewport" content="initial-scale=1, width=device-width, viewport-fit=cover">
-```
-
-
 
 Hiding at startup
 -----------


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The iOS quirk for including `viewport-fit=cover` to make the status bar overlay should be noted directly under `StatusBarOverlaysWebView`. Since iOS 11 is the minimum the plugin supports.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
