### PR TITLE
doc(readme): deprecate plugin, add feature comparison and migration guide against the cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ description: Control the device status bar.
 [![Lint Test](https://github.com/apache/cordova-plugin-statusbar/actions/workflows/lint.yml/badge.svg)](https://github.com/apache/cordova-plugin-statusbar/actions/workflows/lint.yml)
 [![GitHub - Release Audit Workflow](https://github.com/apache/cordova-plugin-statusbar/actions/workflows/release-audit.yml/badge.svg?branch=master)](https://github.com/apache/cordova-plugin-statusbar/actions/workflows/release-audit.yml?query=branch%3Amaster)
 
+> [!WARNING]
+> This plugin is deprecated since [cordova-ios 8.0.0](https://cordova.apache.org/announcements/2025/11/23/cordova-ios-8.0.0.html) released on 23 Nov 2025 and [cordova-android 15.0.0](https://cordova.apache.org/announcements/2026/03/06/cordova-android-15.0.0.html) released on 06 Mar 2026 and should not be used anymore. Functionality has moved to the platform cores. Also a Status Bar JavaScript API was introduced on these platforms to handle the status bar additionally. You can read all about in the linked blog articles.
+
 > The `StatusBar` object provides some functions to customize the iOS and Android StatusBar.
 
 ## Installation


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android, iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- This plugin is deprecated since cordova-ios 8.0.0 and cordova-android 15.0.0. Functionality has moved to the platform cores. Also a Status Bar JavaScript API was introduced on these platforms to handle the status bar additionally.
- Add links to the blog articles which mention the deprecation and the suggested changes.
- List features of the plugin with migration informations

Some things to note about the cores:

1. cordova-android lagged the possibility to hide the status bar completely, which is fixed by PR #2000 (https://github.com/apache/cordova-android/pull/2000) but not released yet.
2. Since cordova-android 15.1.0 the dark/light appearance of the status bar can bet by the Status Bar JS API (https://github.com/apache/cordova-android/pull/1971). On iOS this is done automatically since iOS 18.5. For iOS older than 18.5 the PR #1689 (https://github.com/apache/cordova-ios/pull/1689) fixed that, but which is not released.
3. cordova-android lags the possibilty of using the config.xml preference`<preference name="StatusBarOverlaysWebView" value="true" />` in non-edge-to-edge mode, because `StatusBarOverlaysWebView` is not supported by the cores. PR #1991 on cordova-android (https://github.com/apache/cordova-android/pull/1991) adds the functionality back to Android, but @dpogue mentioned, that this should be done by `<meta name="viewport" content="viewport-fit=cover|contain">` by a MutationObserver in JavaScript. On iOS this behaviour can already be obtained by using `<meta name="viewport" content="viewport-fit=cover“>`. @dpogue opened a PR #2010 on cordova-android (https://github.com/apache/cordova-android/pull/2010) which would resolve this.

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
